### PR TITLE
Add Sigma S1 hardware docs and CAD

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -2,3 +2,4 @@ ESP32
 Whisper
 LLM
 OpenSCAD
+WROOM

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 Sigma is an open-source ESP32 "AI pin" that lets you talk to a language model via a push‑to‑talk button. Audio is captured and sent to Whisper for speech recognition, routed through the LLM of your choice, then played back with low‑latency text‑to‑speech in a 3D‑printed OpenSCAD case.
 
+Hardware models for the enclosure live in [`hardware/cad`](hardware/cad) with assembly instructions in [`docs/sigma-s1-assembly.md`](docs/sigma-s1-assembly.md).
+
 ## Getting Started
 
 1. Install [PlatformIO](https://platformio.org/).
@@ -57,4 +59,3 @@ Pull requests are welcome! Please open an issue first to discuss major changes. 
 ## Origin of the Name
 
 "Sigma" just sounds cool. If you prefer an acronym, call it **Secure Interactive Gizmo Materializing AI (S.I.G.M.A.)**. Feel free to rebrand it in your own fork.
-

--- a/docs/sigma-s1-assembly.md
+++ b/docs/sigma-s1-assembly.md
@@ -1,0 +1,49 @@
+# Sigma S1 Assembly Guide
+
+This guide explains how to build the Sigma S1 push‑to‑talk device.
+The design uses an ESP32‑WROOM module, a microphone, speaker and
+an AA battery compartment housed in a 3D printed enclosure.
+
+See `hardware/cad/sigma-s1-enclosure.scad` for the OpenSCAD model.
+
+## Bill of Materials
+
+- ESP32‑WROOM module
+- Electret microphone module
+- Mini speaker (8 Ω)
+- Push button
+- 2× AA battery holder
+- Miscellaneous wires and screws
+
+## Printing the Case
+
+1. Open `sigma-s1-enclosure.scad` in OpenSCAD.
+2. Adjust the `thickness` and overall dimensions if needed.
+3. Export to STL and print with 0.2 mm layer height.
+
+## Wiring Diagram
+
+```
+[Button] --+-- [Mic]
+           |
+        [ESP32]
+           |
+        [Speaker]
+           |
+      [AA Holder]
+```
+
+The ESP32 sits in the upper section while the batteries slide into the
+compartment at the bottom. Route the microphone and speaker wires through
+the side openings before closing the shell.
+
+## Assembly Steps
+
+1. Solder the microphone and speaker leads to the ESP32.
+2. Attach the push button to a GPIO pin and ground.
+3. Place the ESP32 into the printed case.
+4. Insert the AA holder and feed its leads to the module.
+5. Close the enclosure with small screws or glue as preferred.
+
+A future update will include a 3D viewer so you can inspect the model
+right from the repository.

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -1,0 +1,10 @@
+# Hardware
+
+This folder contains CAD files and reference diagrams for the Sigma S1
+push‑to‑talk device. Models are written in OpenSCAD so you can tweak
+dimensions as needed.
+
+- `cad/` – OpenSCAD models for 3D printing
+
+See [docs/sigma-s1-assembly.md](../docs/sigma-s1-assembly.md) for a full
+bill of materials and assembly instructions.

--- a/hardware/cad/sigma-s1-enclosure.scad
+++ b/hardware/cad/sigma-s1-enclosure.scad
@@ -1,0 +1,24 @@
+// Simple enclosure for Sigma S1
+// Designed for ESP32-WROOM module with mic, speaker, and AA battery compartment
+// Parameters allow tweaking wall thickness and overall dimensions
+
+thickness = 2;            // wall thickness in mm
+width = 60;               // enclosure width in mm
+height = 80;              // enclosure height in mm
+depth = 30;               // enclosure depth in mm
+battery_length = 52;      // length of AA battery compartment
+
+module shell() {
+    difference() {
+        // outer shell
+        cube([width, depth, height], center=false);
+        // hollow interior
+        translate([thickness, thickness, thickness])
+            cube([width-2*thickness, depth-2*thickness, height-2*thickness], center=false);
+        // battery cutout at bottom
+        translate([(width-battery_length)/2, depth-1, thickness])
+            cube([battery_length, 1, 14], center=false);
+    }
+}
+
+shell();


### PR DESCRIPTION
## Summary
- document new enclosure CAD files for the Sigma S1 push-to-talk device
- add assembly instructions and wiring diagram
- include hardware folder in README and wordlist
- fix trailing blank line in README

## Testing
- `make test`
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_686e3c5f79d8832f8d38b22d517ce1ee