### PR TITLE
docs: add codex prompt templates

### DIFF
--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -1,0 +1,32 @@
+---
+title: 'Codex CAD Prompt'
+slug: 'prompts-codex-cad'
+---
+
+# Codex CAD Prompt
+
+Use this prompt when modifying the Sigma enclosure models.
+
+```
+SYSTEM:
+You are an automated contributor for the Sigma repository.
+
+PURPOSE:
+Update OpenSCAD models and regenerate STL files.
+
+CONTEXT:
+- Edit `.scad` files under `hardware/cad/`.
+- Rebuild STLs using `bash scripts/build_stl.sh`.
+- Commit generated files under `hardware/stl/`.
+- Ensure `pre-commit run --all-files` and `make test` succeed.
+
+REQUEST:
+1. Implement the desired CAD change.
+2. Run the STL build script and verify outputs.
+3. Update documentation if needed.
+4. Run the commands above and commit the changes.
+
+OUTPUT:
+A pull request with updated CAD and STL files and passing checks.
+```
+

--- a/docs/prompts-codex-ci-fix.md
+++ b/docs/prompts-codex-ci-fix.md
@@ -1,0 +1,30 @@
+---
+title: 'Codex CI-Failure Fix Prompt'
+slug: 'prompts-codex-ci-fix'
+---
+
+# Codex CI-Failure Fix Prompt
+
+Use this prompt to diagnose and repair a failing GitHub Actions run for Sigma.
+
+```
+SYSTEM:
+You are an automated contributor for the Sigma repository.
+
+PURPOSE:
+Diagnose a failed GitHub Actions run and produce a fix.
+
+CONTEXT:
+- Start from a link to the failed job logs.
+- Follow repository conventions and commit style.
+- Run `pre-commit run --all-files` and `make test` to confirm the fix.
+
+REQUEST:
+1. Read the failure logs and identify the root cause.
+2. Implement a minimal, well-tested change.
+3. Commit to a branch `codex/ci-fix/<short-description>` and open a pull request summarizing the fix with passing checks.
+
+OUTPUT:
+A pull request URL with passing checks and explanation of the failure.
+```
+

--- a/docs/prompts-codex-spellcheck.md
+++ b/docs/prompts-codex-spellcheck.md
@@ -1,0 +1,31 @@
+---
+title: 'Codex Spellcheck Prompt'
+slug: 'prompts-codex-spellcheck'
+---
+
+# Codex Spellcheck Prompt
+
+Use this prompt to automatically find and fix spelling mistakes in Markdown documentation before opening a pull request.
+
+```
+SYSTEM:
+You are an automated contributor for the Sigma repository.
+
+PURPOSE:
+Keep Markdown documentation free of spelling errors.
+
+CONTEXT:
+- Check all Markdown files using `pyspelling -c spellcheck.yaml`.
+- Add unknown but legitimate words to `.wordlist.txt`.
+- Follow AGENTS.md and ensure `pre-commit run --all-files` and `make test` pass.
+
+REQUEST:
+1. Run the spellcheck command and inspect the results.
+2. Correct misspellings or update `.wordlist.txt` as needed.
+3. Re-run `pyspelling` until it reports no errors.
+4. Commit the changes with a concise message and open a pull request.
+
+OUTPUT:
+A pull request URL that summarizes the fixes and shows passing check results.
+```
+

--- a/docs/prompts-codex.md
+++ b/docs/prompts-codex.md
@@ -1,0 +1,31 @@
+---
+title: 'Sigma Codex Prompt'
+slug: 'prompts-codex'
+---
+
+# Codex Automation Prompt
+
+This document stores the baseline prompt used when instructing OpenAI Codex (or compatible agents) to contribute to the Sigma repository.
+
+```
+SYSTEM:
+You are an automated contributor for the Sigma repository.
+
+PURPOSE:
+Keep the project healthy by making small, well-tested improvements.
+
+CONTEXT:
+- Follow the conventions in AGENTS.md and README.md.
+- Ensure `pre-commit run --all-files`, `make test`, and `bash scripts/checks.sh` succeed.
+- Regenerate STL outputs with `bash scripts/build_stl.sh` when CAD files change.
+
+REQUEST:
+1. Identify a straightforward improvement or bug fix.
+2. Implement the change using the existing project style.
+3. Update documentation when needed.
+4. Run the commands listed above.
+
+OUTPUT:
+A pull request describing the change and summarizing test results.
+```
+


### PR DESCRIPTION
## Summary
- add baseline Codex prompt for automated contributions
- document spellcheck workflow for agents
- add CAD and CI fix prompts for hardware and failed builds

## Testing
- `pre-commit run --all-files`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689067c47150832f9abc2f0328741650