### PR TITLE
✨ : – add llm endpoint parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ pre-commit install
 
 Helper scripts for STT, TTS and the LLM API live in `software/`. Configure the endpoint you want to use in [`llms.txt`](llms.txt).
 
+You can list the configured endpoints with:
+
+```bash
+python -m llms
+```
+
 See [`AGENTS.md`](AGENTS.md) for details on how we integrate LLMs and prompts.
 
 ## Testing

--- a/docs/prompts-codex-cad.md
+++ b/docs/prompts-codex-cad.md
@@ -29,4 +29,3 @@ REQUEST:
 OUTPUT:
 A pull request with updated CAD and STL files and passing checks.
 ```
-

--- a/docs/prompts-codex-ci-fix.md
+++ b/docs/prompts-codex-ci-fix.md
@@ -27,4 +27,3 @@ REQUEST:
 OUTPUT:
 A pull request URL with passing checks and explanation of the failure.
 ```
-

--- a/docs/prompts-codex-spellcheck.md
+++ b/docs/prompts-codex-spellcheck.md
@@ -28,4 +28,3 @@ REQUEST:
 OUTPUT:
 A pull request URL that summarizes the fixes and shows passing check results.
 ```
-

--- a/docs/prompts-codex.md
+++ b/docs/prompts-codex.md
@@ -28,4 +28,3 @@ REQUEST:
 OUTPUT:
 A pull request describing the change and summarizing test results.
 ```
-

--- a/llms.py
+++ b/llms.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import List, Tuple
+
+
+def get_llm_endpoints(path: str = "llms.txt") -> List[Tuple[str, str]]:
+    """Return LLM endpoints listed in ``llms.txt``.
+
+    Parameters
+    ----------
+    path: str
+        Path to the ``llms.txt`` file.
+
+    Returns
+    -------
+    List[Tuple[str, str]]
+        List of ``(name, url)`` tuples for each configured endpoint.
+    """
+
+    lines = Path(path).read_text(encoding="utf-8").splitlines()
+    pattern = re.compile(r"^- \[(?P<name>[^\]]+)\]\((?P<url>https?://[^)]+)\)")
+    endpoints: List[Tuple[str, str]] = []
+    for line in lines:
+        match = pattern.match(line.strip())
+        if match:
+            endpoints.append((match.group("name"), match.group("url")))
+    return endpoints
+
+
+if __name__ == "__main__":
+    for name, url in get_llm_endpoints():
+        print(f"{name}: {url}")

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -1,0 +1,12 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import llms  # noqa: E402
+
+
+def test_get_llm_endpoints_parses_file():
+    endpoints = dict(llms.get_llm_endpoints())
+    assert "token.place" in endpoints
+    assert endpoints["OpenRouter"] == "https://openrouter.ai/"


### PR DESCRIPTION
what: parse llms.txt into (name, url) pairs and document usage; normalize prompt docs.
why: expose configured endpoints programmatically and keep docs tidy.
how to test: pre-commit run --all-files; make test; bash scripts/checks.sh.
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_6892def63578832f8fd39c4b28f67fcb