### PR TITLE
🐛 : handle missing llms.txt gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ You can list the configured endpoints with:
 python -m llms
 ```
 
+If `llms.txt` is missing the command prints nothing and exits without error.
+
 See [`AGENTS.md`](AGENTS.md) for details on how we integrate LLMs and prompts.
 
 ## Testing

--- a/llms.py
+++ b/llms.py
@@ -17,9 +17,19 @@ def get_llm_endpoints(path: str = "llms.txt") -> List[Tuple[str, str]]:
     -------
     List[Tuple[str, str]]
         List of ``(name, url)`` tuples for each configured endpoint.
+
+    Notes
+    -----
+    If the file does not exist an empty list is returned instead of raising
+    ``FileNotFoundError``.
     """
 
-    lines = Path(path).read_text(encoding="utf-8").splitlines()
+    llms_path = Path(path)
+    try:
+        lines = llms_path.read_text(encoding="utf-8").splitlines()
+    except FileNotFoundError:
+        return []
+
     pattern = re.compile(r"^- \[(?P<name>[^\]]+)\]\((?P<url>https?://[^)]+)\)")
     endpoints: List[Tuple[str, str]] = []
     for line in lines:

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -10,3 +10,9 @@ def test_get_llm_endpoints_parses_file():
     endpoints = dict(llms.get_llm_endpoints())
     assert "token.place" in endpoints
     assert endpoints["OpenRouter"] == "https://openrouter.ai/"
+
+
+def test_get_llm_endpoints_missing_file_returns_empty_list(tmp_path):
+    missing_file = tmp_path / "missing.txt"
+    endpoints = llms.get_llm_endpoints(str(missing_file))
+    assert endpoints == []


### PR DESCRIPTION
what: return empty list when llms.txt is missing
why: avoid FileNotFoundError when listing endpoints
how to test:
- pre-commit run --all-files
- make test
- bash scripts/checks.sh

------
https://chatgpt.com/codex/tasks/task_e_6893e29b9b3c832fa64bbc42fc569b5b