### PR TITLE
✨: – accept Path objects in llm endpoint parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ python -m llms
 
 If `llms.txt` is missing the command prints nothing and exits without error.
 
+The `llms.get_llm_endpoints` helper accepts either a string path or a `pathlib.Path` for custom locations.
+
 See [`AGENTS.md`](AGENTS.md) for details on how we integrate LLMs and prompts.
 
 ## Testing

--- a/llms.py
+++ b/llms.py
@@ -5,12 +5,12 @@ from pathlib import Path
 from typing import List, Tuple
 
 
-def get_llm_endpoints(path: str = "llms.txt") -> List[Tuple[str, str]]:
+def get_llm_endpoints(path: str | Path = "llms.txt") -> List[Tuple[str, str]]:
     """Return LLM endpoints listed in ``llms.txt``.
 
     Parameters
     ----------
-    path: str
+    path: str | Path
         Path to the ``llms.txt`` file.
 
     Returns

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -12,6 +12,11 @@ def test_get_llm_endpoints_parses_file():
     assert endpoints["OpenRouter"] == "https://openrouter.ai/"
 
 
+def test_get_llm_endpoints_accepts_path_object():
+    path = Path("llms.txt")
+    assert llms.get_llm_endpoints(path) == llms.get_llm_endpoints()
+
+
 def test_get_llm_endpoints_missing_file_returns_empty_list(tmp_path):
     missing_file = tmp_path / "missing.txt"
     endpoints = llms.get_llm_endpoints(str(missing_file))


### PR DESCRIPTION
## Summary
- allow `llms.get_llm_endpoints` to take `Path` objects
- document usage in README
- test `Path`-based endpoint loading

## Testing
- `pre-commit run --all-files`
- `make test`
- `bash scripts/checks.sh`

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_6894376096bc832fa09f34c7668e7b79