### PR TITLE
🔧 : resolve llms.txt path relative to module

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ You can list the configured endpoints with:
 python -m llms
 ```
 
-If `llms.txt` is missing the command prints nothing and exits without error.
+If `llms.txt` is missing the command prints nothing and exits without error. The helper
+locates `llms.txt` relative to its own file, so you can run it from any working
+directory.
 
 See [`AGENTS.md`](AGENTS.md) for details on how we integrate LLMs and prompts.
 

--- a/llms.py
+++ b/llms.py
@@ -2,16 +2,16 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 
-def get_llm_endpoints(path: str = "llms.txt") -> List[Tuple[str, str]]:
+def get_llm_endpoints(path: Optional[str] = None) -> List[Tuple[str, str]]:
     """Return LLM endpoints listed in ``llms.txt``.
 
     Parameters
     ----------
-    path: str
-        Path to the ``llms.txt`` file.
+    path: str | None, optional
+        Optional path to ``llms.txt``. Defaults to the copy beside this module.
 
     Returns
     -------
@@ -24,7 +24,10 @@ def get_llm_endpoints(path: str = "llms.txt") -> List[Tuple[str, str]]:
     ``FileNotFoundError``.
     """
 
-    llms_path = Path(path)
+    if path is None:
+        llms_path = Path(__file__).with_name("llms.txt")
+    else:
+        llms_path = Path(path)
     try:
         lines = llms_path.read_text(encoding="utf-8").splitlines()
     except FileNotFoundError:

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -16,3 +16,9 @@ def test_get_llm_endpoints_missing_file_returns_empty_list(tmp_path):
     missing_file = tmp_path / "missing.txt"
     endpoints = llms.get_llm_endpoints(str(missing_file))
     assert endpoints == []
+
+
+def test_get_llm_endpoints_works_from_any_cwd(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    endpoints = dict(llms.get_llm_endpoints())
+    assert "token.place" in endpoints


### PR DESCRIPTION
## Summary
- resolve `llms.txt` path relative to `llms.py`
- test listing endpoints from any working directory
- document default path behavior in README

## Testing
- `pre-commit run --all-files`
- `make test`
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_6894628b698c832f8e620430a9a22767