### PR TITLE
🐛 fix: ignore non-LLM sections in parser

### DIFF
--- a/llms.py
+++ b/llms.py
@@ -20,7 +20,8 @@ def get_llm_endpoints(path: Optional[str] = None) -> List[Tuple[str, str]]:
 
     Notes
     -----
-    If the file does not exist an empty list is returned instead of raising
+    Only bullet links within the ``## LLM Endpoints`` section are parsed. If
+    the file does not exist an empty list is returned instead of raising
     ``FileNotFoundError``.
     """
 
@@ -33,10 +34,18 @@ def get_llm_endpoints(path: Optional[str] = None) -> List[Tuple[str, str]]:
     except FileNotFoundError:
         return []
 
+    # Only parse bullet links in the "## LLM Endpoints" section.
     pattern = re.compile(r"^- \[(?P<name>[^\]]+)\]\((?P<url>https?://[^)]+)\)")
     endpoints: List[Tuple[str, str]] = []
+    in_section = False
     for line in lines:
-        match = pattern.match(line.strip())
+        stripped = line.strip()
+        if stripped.startswith("##"):
+            in_section = stripped == "## LLM Endpoints"
+            continue
+        if not in_section:
+            continue
+        match = pattern.match(stripped)
         if match:
             endpoints.append((match.group("name"), match.group("url")))
     return endpoints

--- a/llms.txt
+++ b/llms.txt
@@ -9,6 +9,7 @@
 - [CONTRIBUTING](CONTRIBUTING.md): contribution workflow
 
 ## LLM Endpoints
+# Parsed by llms.get_llm_endpoints
 - [token.place](https://github.com/futuroptimist/token.place): default stateless API
 - [OpenRouter](https://openrouter.ai/): hosted aggregator of multiple models
 - [OpenAI API](https://platform.openai.com/): commercial chat models
@@ -16,4 +17,5 @@
 - [llama.cpp](https://github.com/ggerganov/llama.cpp): compile models for edge devices
 
 ## Optional
+# Ignored by llms.get_llm_endpoints
 - [GitHub repo](https://github.com/futuroptimist/sigma)

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -22,3 +22,8 @@ def test_get_llm_endpoints_works_from_any_cwd(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     endpoints = dict(llms.get_llm_endpoints())
     assert "token.place" in endpoints
+
+
+def test_get_llm_endpoints_ignores_optional_section():
+    endpoints = dict(llms.get_llm_endpoints())
+    assert "GitHub repo" not in endpoints


### PR DESCRIPTION
## Summary
- parse only links under `## LLM Endpoints` in `llms.txt`
- document parsed and ignored sections in `llms.txt`
- test that optional links are not treated as endpoints

## Testing
- `pre-commit run --files llms.py llms.txt tests/test_llms.py`
- `make test`
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_6896ce277630832fbdd50145646a2dd9