### PR TITLE
🐛: handle uppercase URL schemes in llm endpoints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,9 @@ repos:
     rev: v4.5.0
     hooks:
       - id: trailing-whitespace
+        exclude: hardware/stl/
       - id: end-of-file-fixer
+        exclude: hardware/stl/
       - id: check-yaml
   - repo: local
     hooks:

--- a/llms.py
+++ b/llms.py
@@ -22,6 +22,8 @@ def get_llm_endpoints(path: Optional[str] = None) -> List[Tuple[str, str]]:
     -----
     If the file does not exist an empty list is returned instead of raising
     ``FileNotFoundError``.
+    URL schemes are matched case-insensitively so ``HTTPS`` and ``https``
+    are treated the same.
     """
 
     if path is None:
@@ -33,7 +35,9 @@ def get_llm_endpoints(path: Optional[str] = None) -> List[Tuple[str, str]]:
     except FileNotFoundError:
         return []
 
-    pattern = re.compile(r"^- \[(?P<name>[^\]]+)\]\((?P<url>https?://[^)]+)\)")
+    pattern = re.compile(
+        r"^- \[(?P<name>[^\]]+)\]\((?P<url>https?://[^)]+)\)", re.IGNORECASE
+    )
     endpoints: List[Tuple[str, str]] = []
     for line in lines:
         match = pattern.match(line.strip())

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -22,3 +22,10 @@ def test_get_llm_endpoints_works_from_any_cwd(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     endpoints = dict(llms.get_llm_endpoints())
     assert "token.place" in endpoints
+
+
+def test_get_llm_endpoints_handles_uppercase_scheme(tmp_path):
+    llms_file = tmp_path / "custom.txt"
+    llms_file.write_text("- [Example](HTTPS://example.com)", encoding="utf-8")
+    endpoints = llms.get_llm_endpoints(str(llms_file))
+    assert endpoints == [("Example", "HTTPS://example.com")]


### PR DESCRIPTION
what: allow case-insensitive HTTP schemes and skip hardware/stl/ in EOF
      hooks.
why: uppercase schemes were skipped and binary STLs triggered fixes.
how to test: pre-commit run --all-files, make test, bash
             scripts/checks.sh.


------
https://chatgpt.com/codex/tasks/task_e_6896ce277630832fbdd50145646a2dd9