### PR TITLE
🐛: allow uppercase URL schemes in get_llm_endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ python -m llms
 
 If `llms.txt` is missing the command prints nothing and exits without error. The helper
 locates `llms.txt` relative to its own file, so you can run it from any working
-directory.
+directory. URL schemes in `llms.txt` are matched case-insensitively.
 
 See [`AGENTS.md`](AGENTS.md) for details on how we integrate LLMs and prompts.
 

--- a/llms.py
+++ b/llms.py
@@ -21,7 +21,7 @@ def get_llm_endpoints(path: Optional[str] = None) -> List[Tuple[str, str]]:
     Notes
     -----
     If the file does not exist an empty list is returned instead of raising
-    ``FileNotFoundError``.
+    ``FileNotFoundError``. URL schemes are matched case-insensitively.
     """
 
     if path is None:
@@ -33,7 +33,9 @@ def get_llm_endpoints(path: Optional[str] = None) -> List[Tuple[str, str]]:
     except FileNotFoundError:
         return []
 
-    pattern = re.compile(r"^- \[(?P<name>[^\]]+)\]\((?P<url>https?://[^)]+)\)")
+    pattern = re.compile(
+        r"^- \[(?P<name>[^\]]+)\]\((?P<url>https?://[^)]+)\)", re.IGNORECASE
+    )
     endpoints: List[Tuple[str, str]] = []
     for line in lines:
         match = pattern.match(line.strip())

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -22,3 +22,10 @@ def test_get_llm_endpoints_works_from_any_cwd(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     endpoints = dict(llms.get_llm_endpoints())
     assert "token.place" in endpoints
+
+
+def test_get_llm_endpoints_allows_uppercase_scheme(tmp_path):
+    test_file = tmp_path / "upper.txt"
+    test_file.write_text("- [UPPER](HTTPS://example.com)")
+    endpoints = dict(llms.get_llm_endpoints(str(test_file)))
+    assert endpoints["UPPER"] == "HTTPS://example.com"


### PR DESCRIPTION
what: parse LLM endpoint URLs case-insensitively and test it
why: support endpoints using uppercase HTTP(S)
how to test:
- npm run lint (fails: package.json missing)
- npm run test:ci (fails: package.json missing)
- pre-commit run --all-files
- make test
- bash scripts/checks.sh
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_6896ce277630832fbdd50145646a2dd9