### PR TITLE
🔧 expand user paths – allow ~ in llms.txt path

### DIFF
--- a/llms.py
+++ b/llms.py
@@ -2,16 +2,17 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 
 
-def get_llm_endpoints(path: Optional[str] = None) -> List[Tuple[str, str]]:
+def get_llm_endpoints(path: str | Path | None = None) -> List[Tuple[str, str]]:
     """Return LLM endpoints listed in ``llms.txt``.
 
     Parameters
     ----------
-    path: str | None, optional
-        Optional path to ``llms.txt``. Defaults to the copy beside this module.
+    path: str | Path | None, optional
+        Optional path to ``llms.txt``. ``~`` expands to the user home
+        directory. Defaults to the copy beside this module.
 
     Returns
     -------
@@ -28,7 +29,7 @@ def get_llm_endpoints(path: Optional[str] = None) -> List[Tuple[str, str]]:
     if path is None:
         llms_path = Path(__file__).with_name("llms.txt")
     else:
-        llms_path = Path(path)
+        llms_path = Path(path).expanduser()
     try:
         lines = llms_path.read_text(encoding="utf-8").splitlines()
     except FileNotFoundError:

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -27,3 +27,14 @@ def test_get_llm_endpoints_works_from_any_cwd(tmp_path, monkeypatch):
 def test_get_llm_endpoints_ignores_optional_section():
     endpoints = dict(llms.get_llm_endpoints())
     assert "GitHub repo" not in endpoints
+
+
+def test_get_llm_endpoints_expands_user_paths(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    path = tmp_path / "custom.txt"
+    path.write_text(
+        "## LLM Endpoints\n- [foo](https://example.com)\n",
+        encoding="utf-8",
+    )
+    endpoints = dict(llms.get_llm_endpoints("~/custom.txt"))
+    assert endpoints == {"foo": "https://example.com"}


### PR DESCRIPTION
what: expand get_llm_endpoints to support '~' via Path.expanduser
why: tilde paths previously returned no endpoints
how to test:
  pre-commit run --all-files
  make test
  bash scripts/checks.sh
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_6896ec4fd154832fa691964a2702f35f