### PR TITLE
🧹 chore: enforce strict mode in checks script

### DIFF
--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
 flake8 . --exclude=.venv
 isort --check-only . --skip .venv

--- a/tests/test_checks_script.py
+++ b/tests/test_checks_script.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+
+def test_checks_script_uses_strict_mode():
+    script = Path("scripts/checks.sh")
+    content = script.read_text(encoding="utf-8").splitlines()
+    assert any(line.strip() == "set -euo pipefail" for line in content)


### PR DESCRIPTION
## Summary
- enforce `set -euo pipefail` in `scripts/checks.sh`
- cover strict-mode requirement with unit test

## Testing
- `pre-commit run --all-files`
- `make test`
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_6896ec4fd154832fa691964a2702f35f