### PR TITLE
docs: fix open-source spelling

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -30,6 +30,7 @@ pyspelling
 README
 rebrand
 repo
+roadmap
 Roadmap
 STL
 stl

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,8 @@
 # Sigma Agents Guide
 
-This file helps AI agents like OpenAI Codex understand the structure and workflows of the **Sigma** project. Sigma is a fully open-source ESP32 "AI pin" that uses Whisper for speech recognition, routes text to a configurable LLM, and replies with text-to-speech.
+This file helps AI agents like OpenAI Codex understand the structure and workflows of the
+**Sigma** project. Sigma is a fully open-source ESP32 "AI pin" that uses Whisper for speech
+recognition, routes text to a configurable LLM, and replies with text-to-speech.
 
 ## Project Structure
 - `/firmware` – PlatformIO project for the ESP32


### PR DESCRIPTION
## Summary
- fix broken “open-source” word in AGENTS.md
- add “roadmap” to the spellcheck wordlist

## Testing
- `pyspelling -c spellcheck.yaml`
- `pre-commit run --all-files`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6896ec2a0768832f937ce01962e7cae4