### PR TITLE
Fix pre-commit checks by installing lint deps

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,5 +10,10 @@ repos:
       - id: run-checks
         name: Run checks
         entry: bash scripts/checks.sh
-        language: system
+        language: python
+        additional_dependencies:
+          - flake8
+          - isort
+          - black
+          - pytest
         pass_filenames: false


### PR DESCRIPTION
## Summary
- ensure pre-commit installs flake8, isort, black, pytest for local hook

## Testing
- `pre-commit run --all-files`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6896ec05ef78832fae40f18182c18f14