### PR TITLE
Add average percentile utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,18 @@ Run the test suite with Make:
 make test
 ```
 
+## Utilities
+
+Helper functions live in the `sigma` package. For example, `average_percentile`
+returns the mean percentile rank of a sequence:
+
+```python
+from sigma.utils import average_percentile
+
+values = [1, 2, 3]
+print(average_percentile(values))  # 66.666...
+```
+
 ## Roadmap
 
 - [ ] Breadboard MVP with a button toggling an LED

--- a/sigma/__init__.py
+++ b/sigma/__init__.py
@@ -1,0 +1,5 @@
+"""Sigma utility package."""
+
+from .utils import average_percentile
+
+__all__ = ["average_percentile"]

--- a/sigma/utils.py
+++ b/sigma/utils.py
@@ -1,0 +1,23 @@
+"""Utility functions for the Sigma project."""
+
+from bisect import bisect_right
+from typing import Sequence
+
+
+def average_percentile(values: Sequence[float]) -> float:
+    """Return the average percentile rank of *values* within the list.
+
+    Each value's percentile rank is computed as the percentage of entries less
+    than or equal to it. The function returns the mean of these percentiles and
+    raises ``ValueError`` if *values* is empty.
+    """
+    if not values:
+        raise ValueError("values must be non-empty")
+
+    sorted_vals = sorted(values)
+    n = len(sorted_vals)
+    total = 0.0
+    for v in values:
+        rank = bisect_right(sorted_vals, v)
+        total += (rank / n) * 100
+    return total / n

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,22 @@
+import math
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from sigma.utils import average_percentile  # noqa: E402
+
+
+def test_average_percentile_basic():
+    values = [1, 2, 3]
+    expected = 66.6666666667
+    assert math.isclose(average_percentile(values), expected, rel_tol=1e-9)
+
+
+def test_average_percentile_empty_list_raises():
+    try:
+        average_percentile([])
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("ValueError not raised")


### PR DESCRIPTION
## Summary
- add average_percentile helper
- document utility usage in README
- test percentile computation

## Testing
- `pre-commit run --all-files`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6896ec05ef78832fae40f18182c18f14