### PR TITLE
🐛 fix: parse uppercase URL schemes

### DIFF
--- a/llms.py
+++ b/llms.py
@@ -20,9 +20,10 @@ def get_llm_endpoints(path: Optional[str] = None) -> List[Tuple[str, str]]:
 
     Notes
     -----
-    Only bullet links within the ``## LLM Endpoints`` section are parsed. If
-    the file does not exist an empty list is returned instead of raising
-    ``FileNotFoundError``.
+    Only bullet links within the ``## LLM Endpoints`` section are parsed. URL
+    schemes are matched case-insensitively so ``HTTPS`` and ``https`` are
+    treated the same. If the file does not exist an empty list is returned
+    instead of raising ``FileNotFoundError``.
     """
 
     if path is None:
@@ -35,7 +36,9 @@ def get_llm_endpoints(path: Optional[str] = None) -> List[Tuple[str, str]]:
         return []
 
     # Only parse bullet links in the "## LLM Endpoints" section.
-    pattern = re.compile(r"^- \[(?P<name>[^\]]+)\]\((?P<url>https?://[^)]+)\)")
+    pattern = re.compile(
+        r"^- \[(?P<name>[^\]]+)\]\((?P<url>https?://[^)]+)\)", re.IGNORECASE
+    )
     endpoints: List[Tuple[str, str]] = []
     in_section = False
     for line in lines:

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -24,6 +24,15 @@ def test_get_llm_endpoints_works_from_any_cwd(tmp_path, monkeypatch):
     assert "token.place" in endpoints
 
 
+def test_get_llm_endpoints_handles_uppercase_scheme(tmp_path):
+    llms_file = tmp_path / "custom.txt"
+    llms_file.write_text(
+        "## LLM Endpoints\n- [Example](HTTPS://example.com)", encoding="utf-8"
+    )
+    endpoints = llms.get_llm_endpoints(str(llms_file))
+    assert endpoints == [("Example", "HTTPS://example.com")]
+
+
 def test_get_llm_endpoints_ignores_optional_section():
     endpoints = dict(llms.get_llm_endpoints())
     assert "GitHub repo" not in endpoints


### PR DESCRIPTION
## Summary
- handle uppercase HTTPS URLs when reading llms.txt
- test parser with uppercase scheme

## Testing
- `pre-commit run --all-files`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6896ec05ef78832fae40f18182c18f14