### PR TITLE
🐛 : validate percentile inputs

### DIFF
--- a/sigma/utils.py
+++ b/sigma/utils.py
@@ -1,5 +1,6 @@
 """Utility functions for the Sigma project."""
 
+import math
 from bisect import bisect_left, bisect_right
 from typing import Sequence
 
@@ -11,10 +12,12 @@ def average_percentile(values: Sequence[float]) -> float:
     than the value plus half of the entries equal to it. This "midrank" method
     avoids skewing the result when duplicates are present. The function returns
     the mean of these percentiles and raises ``ValueError`` if *values* is
-    empty.
+    empty or contains non-finite numbers such as ``NaN`` or ``inf``.
     """
     if not values:
         raise ValueError("values must be non-empty")
+    if any(not math.isfinite(v) for v in values):
+        raise ValueError("values must be finite numbers")
 
     sorted_vals = sorted(values)
     n = len(sorted_vals)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,8 @@ import math
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from sigma.utils import average_percentile  # noqa: E402
@@ -21,9 +23,10 @@ def test_average_percentile_with_duplicates():
 
 
 def test_average_percentile_empty_list_raises():
-    try:
+    with pytest.raises(ValueError):
         average_percentile([])
-    except ValueError:
-        pass
-    else:
-        raise AssertionError("ValueError not raised")
+
+
+def test_average_percentile_non_finite_raises():
+    with pytest.raises(ValueError):
+        average_percentile([1.0, math.nan])


### PR DESCRIPTION
## Summary
- raise ValueError when average_percentile receives NaN or infinity
- test non-finite handling and use pytest.raises

## Testing
- `pre-commit run --all-files`
- `make test`
- `bash scripts/checks.sh`
- `npm run lint` *(fails: package.json not found)*
- `npm run test:ci` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68991880dc44832fa854d4b8c71ea603