### PR TITLE
🐛 fix: support iterable inputs in average_percentile

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ make test
 ## Utilities
 
 Helper functions live in the `sigma` package. For example, `average_percentile`
-returns the mean percentile rank of a sequence:
+returns the mean percentile rank of an iterable:
 
 ```python
 from sigma.utils import average_percentile

--- a/sigma/utils.py
+++ b/sigma/utils.py
@@ -1,25 +1,27 @@
 """Utility functions for the Sigma project."""
 
 from bisect import bisect_left, bisect_right
-from typing import Sequence
+from typing import Iterable
 
 
-def average_percentile(values: Sequence[float]) -> float:
-    """Return the average percentile rank of *values* within the list.
+def average_percentile(values: Iterable[float]) -> float:
+    """Return the average percentile rank of *values* within the iterable.
 
-    Each value's percentile rank is computed as the percentage of entries less
-    than the value plus half of the entries equal to it. This "midrank" method
+    The input may be any iterable such as a list, tuple, or generator. Each
+    value's percentile rank is computed as the percentage of entries less than
+    the value plus half of the entries equal to it. This "midrank" method
     avoids skewing the result when duplicates are present. The function returns
     the mean of these percentiles and raises ``ValueError`` if *values* is
     empty.
     """
-    if not values:
+    vals = list(values)
+    if not vals:
         raise ValueError("values must be non-empty")
 
-    sorted_vals = sorted(values)
+    sorted_vals = sorted(vals)
     n = len(sorted_vals)
     total = 0.0
-    for v in values:
+    for v in vals:
         lo = bisect_left(sorted_vals, v)
         hi = bisect_right(sorted_vals, v)
         rank = (lo + hi) / 2

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,3 +27,9 @@ def test_average_percentile_empty_list_raises():
         pass
     else:
         raise AssertionError("ValueError not raised")
+
+
+def test_average_percentile_accepts_generators():
+    values = (v for v in [1, 2, 3])
+    expected = 50.0
+    assert math.isclose(average_percentile(values), expected, rel_tol=1e-9)


### PR DESCRIPTION
## Summary
- allow `average_percentile` to accept any iterable without exhausting generators
- document iterable support and test generator inputs

## Testing
- `python -m pre_commit run --all-files`
- `make test`
- `PATH=$PATH:/root/.pyenv/versions/3.12.10/bin bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68991880dc44832fa854d4b8c71ea603