### PR TITLE
📝 docs: correct average_percentile example output

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ returns the mean percentile rank of a sequence:
 from sigma.utils import average_percentile
 
 values = [1, 2, 3]
-print(average_percentile(values))  # 66.666...
+print(average_percentile(values))  # 50.0
 ```
 
 ## Roadmap


### PR DESCRIPTION
## Summary
- fix README example of `average_percentile`

## Testing
- `/root/.pyenv/versions/3.12.10/bin/pre-commit run --all-files`
- `make test`
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68991880dc44832fa854d4b8c71ea603