### PR TITLE
🐛 fix: skip codecov upload without token

### DIFF
--- a/.github/workflows/02-tests.yml
+++ b/.github/workflows/02-tests.yml
@@ -15,5 +15,6 @@ jobs:
           coverage run -m pytest -q
           coverage xml
       - uses: codecov/codecov-action@v5
+        if: ${{ secrets.CODECOV_TOKEN != '' }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- guard Codecov upload so tests pass without CODECOV_TOKEN

## Testing
- `python -m pre_commit run --all-files`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6899187b1db8832f94a7d6130cc82858