### PR TITLE
🛠️ ci: run linters via python modules

### DIFF
--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-flake8 . --exclude=.venv
-isort --check-only . --skip .venv
-black --check . --exclude ".venv/"
+python -m flake8 . --exclude=.venv
+python -m isort --check-only . --skip .venv
+python -m black --check . --exclude ".venv/"
 
 pytest -q


### PR DESCRIPTION
what: invoke flake8, isort, and black with python -m in checks script
why: ensure CI finds linters even without console entrypoints
how to test: pre-commit run --all-files && make test


------
https://chatgpt.com/codex/tasks/task_e_6899187b1db8832f94a7d6130cc82858