### PR TITLE
🔧 widen USB-C cutout for better cable clearance

### DIFF
--- a/hardware/README.md
+++ b/hardware/README.md
@@ -5,8 +5,9 @@ push‑to‑talk device. Models are written in OpenSCAD so you can tweak
 dimensions as needed.
 
 The enclosure includes cutouts for the button, microphone, speaker, battery,
-USB-C port, and a small lanyard hole for attaching a strap. The hole measures 5 mm in
-diameter and sits 6 mm from the left edge.
+USB-C port, and a small lanyard hole for attaching a strap. The hole measures
+5 mm in diameter and sits 6 mm from the left edge. The USB-C cutout is 12 mm
+wide for improved cable clearance.
 
 - `cad/` – OpenSCAD models for 3D printing
 - `stl/` – auto-generated STL exports

--- a/hardware/cad/sigma-s1-enclosure.scad
+++ b/hardware/cad/sigma-s1-enclosure.scad
@@ -16,7 +16,7 @@ speaker_d = 10;       // overall speaker area
 speaker_holes = 7;    // number of speaker vents
 lanyard_d = 5;        // diameter of lanyard hole
 lanyard_offset = 6;   // distance from left edge
-usb_w = 10;           // width of USB-C cutout
+usb_w = 12;           // width of USB-C cutout (increased for cable clearance)
 usb_h = 4;            // height of USB-C cutout
 usb_z = 10;           // distance from bottom to cutout
 

--- a/hardware/stl/sigma-s1-enclosure.stl
+++ b/hardware/stl/sigma-s1-enclosure.stl
@@ -29,7 +29,7 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 -1 0
     outer loop
-      vertex 35 0 16
+      vertex 36 0 16
       vertex 39.4221 0 39.5802
       vertex 20.4635 0 38.5734
     endloop
@@ -282,7 +282,7 @@ solid OpenSCAD_Model
   facet normal 0 -1 0
     outer loop
       vertex 18.7865 0 39.1183
-      vertex 25 0 16
+      vertex 24 0 16
       vertex 20.4635 0 38.5734
     endloop
   endfacet
@@ -297,21 +297,21 @@ solid OpenSCAD_Model
     outer loop
       vertex 18.7865 0 39.1183
       vertex 0 0 0
-      vertex 25 0 16
+      vertex 24 0 16
     endloop
   endfacet
   facet normal 0 -1 -0
     outer loop
-      vertex 25 0 12
+      vertex 24 0 12
       vertex 0 0 0
-      vertex 35 0 12
+      vertex 36 0 12
     endloop
   endfacet
   facet normal 0 -1 -0
     outer loop
-      vertex 25 0 16
+      vertex 24 0 16
       vertex 0 0 0
-      vertex 25 0 12
+      vertex 24 0 12
     endloop
   endfacet
   facet normal 0 -1 0
@@ -484,15 +484,15 @@ solid OpenSCAD_Model
   endfacet
   facet normal 0 -1 0
     outer loop
-      vertex 35 0 16
+      vertex 36 0 16
       vertex 20.4635 0 38.5734
-      vertex 25 0 16
+      vertex 24 0 16
     endloop
   endfacet
   facet normal 0 -1 -0
     outer loop
       vertex 39.4221 0 39.5802
-      vertex 35 0 16
+      vertex 36 0 16
       vertex 40.2207 0 39.3207
     endloop
   endfacet
@@ -500,7 +500,7 @@ solid OpenSCAD_Model
     outer loop
       vertex 60 0 0
       vertex 40.2207 0 39.3207
-      vertex 35 0 16
+      vertex 36 0 16
     endloop
   endfacet
   facet normal 0 -1 0
@@ -513,8 +513,8 @@ solid OpenSCAD_Model
   facet normal 0 -1 0
     outer loop
       vertex 60 0 0
-      vertex 35 0 16
-      vertex 35 0 12
+      vertex 36 0 16
+      vertex 36 0 12
     endloop
   endfacet
   facet normal 0 -1 0
@@ -527,7 +527,7 @@ solid OpenSCAD_Model
   facet normal 0 -1 0
     outer loop
       vertex 60 0 0
-      vertex 35 0 12
+      vertex 36 0 12
       vertex 0 0 0
     endloop
   endfacet
@@ -1122,48 +1122,48 @@ solid OpenSCAD_Model
   facet normal 0 1 0
     outer loop
       vertex 58 2 78
-      vertex 35 2 16
+      vertex 36 2 16
       vertex 2 2 78
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
       vertex 58 2 2
-      vertex 35 2 16
+      vertex 36 2 16
       vertex 58 2 78
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 35 2 12
+      vertex 36 2 12
       vertex 58 2 2
-      vertex 25 2 12
+      vertex 24 2 12
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 35 2 16
+      vertex 36 2 16
       vertex 58 2 2
-      vertex 35 2 12
+      vertex 36 2 12
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex 25 2 16
+      vertex 24 2 16
       vertex 2 2 78
-      vertex 35 2 16
+      vertex 36 2 16
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
       vertex 2 2 2
-      vertex 25 2 16
-      vertex 25 2 12
+      vertex 24 2 16
+      vertex 24 2 12
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 25 2 16
+      vertex 24 2 16
       vertex 2 2 2
       vertex 2 2 78
     endloop
@@ -1171,7 +1171,7 @@ solid OpenSCAD_Model
   facet normal 0 1 0
     outer loop
       vertex 2 2 2
-      vertex 25 2 12
+      vertex 24 2 12
       vertex 58 2 2
     endloop
   endfacet
@@ -1359,58 +1359,58 @@ solid OpenSCAD_Model
   endfacet
   facet normal -1 0 0
     outer loop
-      vertex 35 0 12
-      vertex 35 2 16
-      vertex 35 2 12
+      vertex 36 0 12
+      vertex 36 2 16
+      vertex 36 2 12
     endloop
   endfacet
   facet normal -1 -0 0
     outer loop
-      vertex 35 2 16
-      vertex 35 0 12
-      vertex 35 0 16
+      vertex 36 2 16
+      vertex 36 0 12
+      vertex 36 0 16
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 25 0 16
-      vertex 35 2 16
-      vertex 35 0 16
+      vertex 24 0 16
+      vertex 36 2 16
+      vertex 36 0 16
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 35 2 16
-      vertex 25 0 16
-      vertex 25 2 16
+      vertex 36 2 16
+      vertex 24 0 16
+      vertex 24 2 16
     endloop
   endfacet
   facet normal -0 0 1
     outer loop
-      vertex 25 2 12
-      vertex 35 0 12
-      vertex 35 2 12
+      vertex 24 2 12
+      vertex 36 0 12
+      vertex 36 2 12
     endloop
   endfacet
   facet normal 0 0 1
     outer loop
-      vertex 35 0 12
-      vertex 25 2 12
-      vertex 25 0 12
+      vertex 36 0 12
+      vertex 24 2 12
+      vertex 24 0 12
     endloop
   endfacet
   facet normal 1 -0 0
     outer loop
-      vertex 25 0 16
-      vertex 25 2 12
-      vertex 25 2 16
+      vertex 24 0 16
+      vertex 24 2 12
+      vertex 24 2 16
     endloop
   endfacet
   facet normal 1 0 0
     outer loop
-      vertex 25 2 12
-      vertex 25 0 16
-      vertex 25 0 12
+      vertex 24 2 12
+      vertex 24 0 16
+      vertex 24 0 12
     endloop
   endfacet
 endsolid OpenSCAD_Model


### PR DESCRIPTION
## Summary
- widen USB-C cutout to 12mm and regenerate STL
- document wider port in hardware README

## Testing
- `bash scripts/build_stl.sh`
- `pre-commit run --all-files`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689918719120832f8ebc0b1e36352bdd