### PR TITLE
Add percentile_rank utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ values = [1, 2, 3]
 print(average_percentile(values))  # 50.0
 ```
 
+The percentile rank of a single value is available via `percentile_rank`:
+
+```python
+from sigma.utils import percentile_rank
+
+print(percentile_rank(2, [1, 2, 3]))  # 50.0
+```
+
 ## Roadmap
 
 - [ ] Breadboard MVP with a button toggling an LED

--- a/sigma/__init__.py
+++ b/sigma/__init__.py
@@ -1,5 +1,5 @@
 """Sigma utility package."""
 
-from .utils import average_percentile
+from .utils import average_percentile, percentile_rank
 
-__all__ = ["average_percentile"]
+__all__ = ["average_percentile", "percentile_rank"]

--- a/sigma/utils.py
+++ b/sigma/utils.py
@@ -5,6 +5,30 @@ from bisect import bisect_left, bisect_right
 from typing import Sequence
 
 
+def _midrank(value: float, sorted_vals: Sequence[float]) -> float:
+    """Return percentile rank of ``value`` given ``sorted_vals``."""
+    lo = bisect_left(sorted_vals, value)
+    hi = bisect_right(sorted_vals, value)
+    rank = (lo + hi) / 2
+    return (rank / len(sorted_vals)) * 100
+
+
+def percentile_rank(value: float, values: Sequence[float]) -> float:
+    """Return the percentile rank of ``value`` within ``values``.
+
+    The percentile is computed using the "midrank" method: the percentage of
+    entries less than ``value`` plus half of the entries equal to it. Raises
+    ``ValueError`` if ``values`` is empty or if any number is non-finite.
+    """
+    if not values:
+        raise ValueError("values must be non-empty")
+    if any(not math.isfinite(v) for v in (*values, value)):
+        raise ValueError("values must be finite numbers")
+
+    sorted_vals = sorted(values)
+    return _midrank(value, sorted_vals)
+
+
 def average_percentile(values: Sequence[float]) -> float:
     """Return the average percentile rank of *values* within the list.
 
@@ -21,10 +45,5 @@ def average_percentile(values: Sequence[float]) -> float:
 
     sorted_vals = sorted(values)
     n = len(sorted_vals)
-    total = 0.0
-    for v in values:
-        lo = bisect_left(sorted_vals, v)
-        hi = bisect_right(sorted_vals, v)
-        rank = (lo + hi) / 2
-        total += (rank / n) * 100
+    total = sum(_midrank(v, sorted_vals) for v in values)
     return total / n

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,7 @@ import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from sigma.utils import average_percentile  # noqa: E402
+from sigma.utils import average_percentile, percentile_rank  # noqa: E402
 
 
 def test_average_percentile_basic():
@@ -30,3 +30,18 @@ def test_average_percentile_empty_list_raises():
 def test_average_percentile_non_finite_raises():
     with pytest.raises(ValueError):
         average_percentile([1.0, math.nan])
+
+
+def test_percentile_rank_basic():
+    values = [1, 2, 3]
+    assert math.isclose(percentile_rank(2, values), 50.0, rel_tol=1e-9)
+
+
+def test_percentile_rank_empty_list_raises():
+    with pytest.raises(ValueError):
+        percentile_rank(1, [])
+
+
+def test_percentile_rank_non_finite_raises():
+    with pytest.raises(ValueError):
+        percentile_rank(math.nan, [1.0])


### PR DESCRIPTION
## Summary
- expose percentile_rank helper alongside average_percentile
- document and test percentile_rank usage

## Testing
- `pre-commit run --all-files`
- `make test`
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_689abb423fdc832fa43d6678d6bc9a19