### PR TITLE
🐛 fix: parse '*' bullets in LLM endpoint parser

### DIFF
--- a/llms.py
+++ b/llms.py
@@ -21,10 +21,11 @@ def get_llm_endpoints(path: str | Path | None = None) -> List[Tuple[str, str]]:
 
     Notes
     -----
-    Only bullet links within the ``## LLM Endpoints`` section are parsed. URL
-    schemes are matched case-insensitively so ``HTTPS`` and ``https`` are
-    treated the same. If the file does not exist an empty list is returned
-    instead of raising ``FileNotFoundError``.
+    Only bullet links starting with ``-`` or ``*`` within the
+    ``## LLM Endpoints`` section are parsed. URL schemes are matched
+    case-insensitively so ``HTTPS`` and ``https`` are treated the same. If the
+    file does not exist an empty list is returned instead of raising
+    ``FileNotFoundError``.
     """
 
     if path is None:
@@ -38,7 +39,8 @@ def get_llm_endpoints(path: str | Path | None = None) -> List[Tuple[str, str]]:
 
     # Only parse bullet links in the "## LLM Endpoints" section.
     pattern = re.compile(
-        r"^- \[(?P<name>[^\]]+)\]\((?P<url>https?://[^)]+)\)", re.IGNORECASE
+        r"^[\-*] \[(?P<name>[^\]]+)\]\((?P<url>https?://[^)]+)\)",
+        re.IGNORECASE,
     )
     endpoints: List[Tuple[str, str]] = []
     in_section = False

--- a/llms.txt
+++ b/llms.txt
@@ -9,7 +9,7 @@
 - [CONTRIBUTING](CONTRIBUTING.md): contribution workflow
 
 ## LLM Endpoints
-# Parsed by llms.get_llm_endpoints
+# Parsed by llms.get_llm_endpoints (bullets may start with '-' or '*')
 - [token.place](https://github.com/futuroptimist/token.place): default stateless API
 - [OpenRouter](https://openrouter.ai/): hosted aggregator of multiple models
 - [OpenAI API](https://platform.openai.com/): commercial chat models

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -47,3 +47,12 @@ def test_get_llm_endpoints_expands_user_paths(tmp_path, monkeypatch):
     )
     endpoints = dict(llms.get_llm_endpoints("~/custom.txt"))
     assert endpoints == {"foo": "https://example.com"}
+
+
+def test_get_llm_endpoints_supports_star_bullets(tmp_path):
+    llms_file = tmp_path / "custom.txt"
+    llms_file.write_text(
+        "## LLM Endpoints\n* [Example](https://example.com)", encoding="utf-8"
+    )
+    endpoints = llms.get_llm_endpoints(str(llms_file))
+    assert endpoints == [("Example", "https://example.com")]


### PR DESCRIPTION
## Summary
- allow '*' list markers in llm endpoint parser
- document bullet support in llms.txt

## Testing
- `python -m pre_commit run --all-files`
- `make test`
- `bash scripts/checks.sh`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689abb423fdc832fa43d6678d6bc9a19