### PR TITLE
Fix Codecov gating in tests workflow

### DIFF
--- a/.github/workflows/02-tests.yml
+++ b/.github/workflows/02-tests.yml
@@ -15,6 +15,6 @@ jobs:
           coverage run -m pytest -q
           coverage xml
       - uses: codecov/codecov-action@v5
-        if: ${{ secrets.CODECOV_TOKEN != '' }}
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+        if: ${{ env.CODECOV_TOKEN != '' }}
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- skip Codecov upload when no token is provided

## Testing
- `pre-commit run --all-files`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689bc111628c832fa3452321b8ab62ff