### PR TITLE
🔧 : call coverage via python -m in tests workflow

### DIFF
--- a/.github/workflows/02-tests.yml
+++ b/.github/workflows/02-tests.yml
@@ -12,8 +12,8 @@ jobs:
           python-version: '3.x'
       - run: uv pip install --system pytest coverage
       - run: |
-          coverage run -m pytest -q
-          coverage xml
+          python -m coverage run -m pytest -q
+          python -m coverage xml
       - uses: codecov/codecov-action@v5
         if: ${{ secrets.CODECOV_TOKEN != '' }}
         with:


### PR DESCRIPTION
what: run coverage via python -m in 02-tests workflow
why: uv installs coverage without exposing CLI, causing GitHub Action failure
how to test: pre-commit run --all-files && make test
Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_689bc111628c832fa3452321b8ab62ff