### PR TITLE
ci: upgrade setup-uv action to v2

### DIFF
--- a/.github/workflows/01-lint-format.yml
+++ b/.github/workflows/01-lint-format.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: astral-sh/setup-uv@v1
+      - uses: astral-sh/setup-uv@v2
       - uses: actions/setup-python@v4
         with:
           python-version: '3.x'

--- a/.github/workflows/03-docs.yml
+++ b/.github/workflows/03-docs.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: astral-sh/setup-uv@v1
+      - uses: astral-sh/setup-uv@v2
       - uses: actions/setup-python@v4
         with:
           python-version: '3.x'


### PR DESCRIPTION
## Summary
- upgrade astral-sh/setup-uv to v2 in lint & docs workflows

## Testing
- `pre-commit run --all-files`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689d5aad24c8832fa42438b8217a4156