### PR TITLE
ci: update GitHub Actions to Node 20

### DIFF
--- a/.github/workflows/01-lint-format.yml
+++ b/.github/workflows/01-lint-format.yml
@@ -5,9 +5,9 @@ jobs:
   lint-format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: astral-sh/setup-uv@v1
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
       - run: uv pip install --system flake8 black isort pytest

--- a/.github/workflows/02-tests.yml
+++ b/.github/workflows/02-tests.yml
@@ -5,7 +5,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'

--- a/.github/workflows/03-docs.yml
+++ b/.github/workflows/03-docs.yml
@@ -9,9 +9,9 @@ jobs:
   linkcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: astral-sh/setup-uv@v1
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
       - run: |

--- a/.github/workflows/scad-to-stl.yml
+++ b/.github/workflows/scad-to-stl.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Install OpenSCAD


### PR DESCRIPTION
## Summary
- fix CI breakage by bumping GitHub Actions to Node 20

## Testing
- `pre-commit run --all-files`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689d5aad24c8832fa42438b8217a4156