### PR TITLE
🩹: parse LLM Endpoints heading case-insensitively

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@ uv pip install pre-commit
 pre-commit install
 ```
 
-Helper scripts for STT, TTS and the LLM API live in `software/`. Configure the endpoint you want to use in [`llms.txt`](llms.txt).
+Helper scripts for STT, TTS and the LLM API live in `software/`.
+Configure the endpoint you want to use in [`llms.txt`](llms.txt).
+The parser matches the `## LLM Endpoints` heading case-insensitively,
+so `## llm endpoints` also works.
 
 You can list the configured endpoints with:
 

--- a/llms.py
+++ b/llms.py
@@ -22,10 +22,10 @@ def get_llm_endpoints(path: str | Path | None = None) -> List[Tuple[str, str]]:
     Notes
     -----
     Only bullet links starting with ``-`` or ``*`` within the
-    ``## LLM Endpoints`` section are parsed. URL schemes are matched
-    case-insensitively so ``HTTPS`` and ``https`` are treated the same. If the
-    file does not exist an empty list is returned instead of raising
-    ``FileNotFoundError``.
+    ``## LLM Endpoints`` section are parsed. The section heading is matched
+    case-insensitively. URL schemes are also matched case-insensitively so
+    ``HTTPS`` and ``https`` are treated the same. If the file does not exist
+    an empty list is returned instead of raising ``FileNotFoundError``.
     """
 
     if path is None:
@@ -47,7 +47,7 @@ def get_llm_endpoints(path: str | Path | None = None) -> List[Tuple[str, str]]:
     for line in lines:
         stripped = line.strip()
         if stripped.startswith("##"):
-            in_section = stripped == "## LLM Endpoints"
+            in_section = stripped.casefold() == "## llm endpoints"
             continue
         if not in_section:
             continue

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -56,3 +56,12 @@ def test_get_llm_endpoints_supports_star_bullets(tmp_path):
     )
     endpoints = llms.get_llm_endpoints(str(llms_file))
     assert endpoints == [("Example", "https://example.com")]
+
+
+def test_get_llm_endpoints_heading_case_insensitive(tmp_path):
+    llms_file = tmp_path / "custom.txt"
+    llms_file.write_text(
+        "## llm endpoints\n- [Example](https://example.com)", encoding="utf-8"
+    )
+    endpoints = dict(llms.get_llm_endpoints(str(llms_file)))
+    assert "Example" in endpoints


### PR DESCRIPTION
## Summary
- allow get_llm_endpoints to match heading regardless of case
- document heading case-insensitivity in README

## Testing
- /root/.pyenv/versions/3.12.10/bin/pre-commit run --all-files
- make test
- bash scripts/checks.sh
- npm run lint (fails: package.json missing)
- npm run test:ci (fails: package.json missing)


------
https://chatgpt.com/codex/tasks/task_e_689eb7226f48832f89d919342f1c3c76