### PR TITLE
🐛 : handle extra spaces after bullet in LLM endpoint parser

### DIFF
--- a/llms.py
+++ b/llms.py
@@ -22,10 +22,10 @@ def get_llm_endpoints(path: str | Path | None = None) -> List[Tuple[str, str]]:
     Notes
     -----
     Only bullet links starting with ``-`` or ``*`` within the
-    ``## LLM Endpoints`` section are parsed. URL schemes are matched
-    case-insensitively so ``HTTPS`` and ``https`` are treated the same. If the
-    file does not exist an empty list is returned instead of raising
-    ``FileNotFoundError``.
+    ``## LLM Endpoints`` section are parsed, and any amount of whitespace
+    after the bullet is ignored. URL schemes are matched case-insensitively
+    so ``HTTPS`` and ``https`` are treated the same. If the file does not
+    exist an empty list is returned instead of raising ``FileNotFoundError``.
     """
 
     if path is None:
@@ -39,7 +39,7 @@ def get_llm_endpoints(path: str | Path | None = None) -> List[Tuple[str, str]]:
 
     # Only parse bullet links in the "## LLM Endpoints" section.
     pattern = re.compile(
-        r"^[\-*] \[(?P<name>[^\]]+)\]\((?P<url>https?://[^)]+)\)",
+        r"^[\-*]\s+\[(?P<name>[^\]]+)\]\((?P<url>https?://[^)]+)\)",
         re.IGNORECASE,
     )
     endpoints: List[Tuple[str, str]] = []

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -56,3 +56,13 @@ def test_get_llm_endpoints_supports_star_bullets(tmp_path):
     )
     endpoints = llms.get_llm_endpoints(str(llms_file))
     assert endpoints == [("Example", "https://example.com")]
+
+
+def test_get_llm_endpoints_allows_extra_space_after_bullet(tmp_path):
+    llms_file = tmp_path / "custom.txt"
+    llms_file.write_text(
+        "## LLM Endpoints\n-  [Example](https://example.com)",
+        encoding="utf-8",
+    )
+    endpoints = llms.get_llm_endpoints(str(llms_file))
+    assert endpoints == [("Example", "https://example.com")]


### PR DESCRIPTION
## Summary
- parse LLM endpoint bullets with additional spaces
- test bullet parsing with extra whitespace

## Testing
- `pre-commit run --all-files`
- `make test`
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_689eb7226f48832f89d919342f1c3c76