### PR TITLE
🩹: support iterable inputs in percentile functions

### DIFF
--- a/sigma/utils.py
+++ b/sigma/utils.py
@@ -2,7 +2,7 @@
 
 import math
 from bisect import bisect_left, bisect_right
-from typing import Sequence
+from typing import Iterable, Sequence
 
 
 def _midrank(value: float, sorted_vals: Sequence[float]) -> float:
@@ -13,37 +13,43 @@ def _midrank(value: float, sorted_vals: Sequence[float]) -> float:
     return (rank / len(sorted_vals)) * 100
 
 
-def percentile_rank(value: float, values: Sequence[float]) -> float:
+def percentile_rank(value: float, values: Iterable[float]) -> float:
     """Return the percentile rank of ``value`` within ``values``.
 
     The percentile is computed using the "midrank" method: the percentage of
     entries less than ``value`` plus half of the entries equal to it. Raises
     ``ValueError`` if ``values`` is empty or if any number is non-finite.
+    ``values`` may be any iterable and is materialized internally, so
+    generators are consumed only once.
     """
-    if not values:
+    vals = list(values)
+    if not vals:
         raise ValueError("values must be non-empty")
-    if any(not math.isfinite(v) for v in (*values, value)):
+    if not math.isfinite(value) or any(not math.isfinite(v) for v in vals):
         raise ValueError("values must be finite numbers")
 
-    sorted_vals = sorted(values)
+    sorted_vals = sorted(vals)
     return _midrank(value, sorted_vals)
 
 
-def average_percentile(values: Sequence[float]) -> float:
+def average_percentile(values: Iterable[float]) -> float:
     """Return the average percentile rank of *values* within the list.
 
     Each value's percentile rank is computed as the percentage of entries less
     than the value plus half of the entries equal to it. This "midrank" method
     avoids skewing the result when duplicates are present. The function returns
     the mean of these percentiles and raises ``ValueError`` if *values* is
-    empty or contains non-finite numbers such as ``NaN`` or ``inf``.
+    empty or contains non-finite numbers such as ``NaN`` or ``inf``. ``values``
+    may be any iterable and is materialized internally, so generators are
+    consumed only once.
     """
-    if not values:
+    vals = list(values)
+    if not vals:
         raise ValueError("values must be non-empty")
-    if any(not math.isfinite(v) for v in values):
+    if any(not math.isfinite(v) for v in vals):
         raise ValueError("values must be finite numbers")
 
-    sorted_vals = sorted(values)
+    sorted_vals = sorted(vals)
     n = len(sorted_vals)
-    total = sum(_midrank(v, sorted_vals) for v in values)
+    total = sum(_midrank(v, sorted_vals) for v in vals)
     return total / n

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -65,3 +65,13 @@ def test_get_llm_endpoints_heading_case_insensitive(tmp_path):
     )
     endpoints = dict(llms.get_llm_endpoints(str(llms_file)))
     assert "Example" in endpoints
+
+
+def test_get_llm_endpoints_allows_indented_bullets(tmp_path):
+    llms_file = tmp_path / "custom.txt"
+    llms_file.write_text(
+        "## LLM Endpoints\n" "  - [Example](https://example.com)",
+        encoding="utf-8",
+    )
+    endpoints = llms.get_llm_endpoints(str(llms_file))
+    assert endpoints == [("Example", "https://example.com")]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -45,3 +45,11 @@ def test_percentile_rank_empty_list_raises():
 def test_percentile_rank_non_finite_raises():
     with pytest.raises(ValueError):
         percentile_rank(math.nan, [1.0])
+
+
+def test_percentile_rank_accepts_generators():
+    def gen():
+        for v in [1.0, 2.0, 3.0]:
+            yield v
+
+    assert math.isclose(percentile_rank(2.0, gen()), 50.0, rel_tol=1e-9)


### PR DESCRIPTION
what: allow percentile helpers to consume any iterable without errors
why: generators exhausted during validation and caused division by zero
how to test: pre-commit run --all-files && make test && bash scripts/checks.sh
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689f8af75bcc832fa998ba028b991226