### PR TITLE
🔧 Support iterables in percentile helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ make test
 ## Utilities
 
 Helper functions live in the `sigma` package. For example, `average_percentile`
-returns the mean percentile rank of a sequence:
+returns the mean percentile rank of an iterable:
 
 ```python
 from sigma.utils import average_percentile

--- a/sigma/utils.py
+++ b/sigma/utils.py
@@ -2,7 +2,7 @@
 
 import math
 from bisect import bisect_left, bisect_right
-from typing import Sequence
+from typing import Iterable, Sequence
 
 
 def _midrank(value: float, sorted_vals: Sequence[float]) -> float:
@@ -13,37 +13,41 @@ def _midrank(value: float, sorted_vals: Sequence[float]) -> float:
     return (rank / len(sorted_vals)) * 100
 
 
-def percentile_rank(value: float, values: Sequence[float]) -> float:
+def percentile_rank(value: float, values: Iterable[float]) -> float:
     """Return the percentile rank of ``value`` within ``values``.
 
     The percentile is computed using the "midrank" method: the percentage of
     entries less than ``value`` plus half of the entries equal to it. Raises
     ``ValueError`` if ``values`` is empty or if any number is non-finite.
+    ``values`` may be any iterable and is internally converted to a list.
     """
-    if not values:
+    values_list = list(values)
+    if not values_list:
         raise ValueError("values must be non-empty")
-    if any(not math.isfinite(v) for v in (*values, value)):
+    if any(not math.isfinite(v) for v in (*values_list, value)):
         raise ValueError("values must be finite numbers")
 
-    sorted_vals = sorted(values)
+    sorted_vals = sorted(values_list)
     return _midrank(value, sorted_vals)
 
 
-def average_percentile(values: Sequence[float]) -> float:
+def average_percentile(values: Iterable[float]) -> float:
     """Return the average percentile rank of *values* within the list.
 
     Each value's percentile rank is computed as the percentage of entries less
     than the value plus half of the entries equal to it. This "midrank" method
     avoids skewing the result when duplicates are present. The function returns
     the mean of these percentiles and raises ``ValueError`` if *values* is
-    empty or contains non-finite numbers such as ``NaN`` or ``inf``.
+    empty or contains non-finite numbers such as ``NaN`` or ``inf``. ``values``
+    may be any iterable and is internally converted to a list.
     """
-    if not values:
+    values_list = list(values)
+    if not values_list:
         raise ValueError("values must be non-empty")
-    if any(not math.isfinite(v) for v in values):
+    if any(not math.isfinite(v) for v in values_list):
         raise ValueError("values must be finite numbers")
 
-    sorted_vals = sorted(values)
+    sorted_vals = sorted(values_list)
     n = len(sorted_vals)
-    total = sum(_midrank(v, sorted_vals) for v in values)
+    total = sum(_midrank(v, sorted_vals) for v in values_list)
     return total / n

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -45,3 +45,14 @@ def test_percentile_rank_empty_list_raises():
 def test_percentile_rank_non_finite_raises():
     with pytest.raises(ValueError):
         percentile_rank(math.nan, [1.0])
+
+
+def test_percentile_rank_accepts_iterable():
+    values = (v for v in [1, 2, 3])
+    assert math.isclose(percentile_rank(2, values), 50.0, rel_tol=1e-9)
+
+
+def test_average_percentile_accepts_iterable():
+    values = (v for v in [1, 2, 3])
+    expected = 50.0
+    assert math.isclose(average_percentile(values), expected, rel_tol=1e-9)


### PR DESCRIPTION
## Summary
- allow percentile_rank and average_percentile to accept any iterable
- document iterable support in README
- test iterable inputs for percentile helpers

## Testing
- `pre-commit run --all-files`
- `make test`
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_689f8af75bcc832fa998ba028b991226