### PR TITLE
🐛: expand env vars in llm path

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ python -m llms
 
 If `llms.txt` is missing the command prints nothing and exits without error. The helper
 locates `llms.txt` relative to its own file, so you can run it from any working
-directory.
+directory. The optional path argument to ``llms.get_llm_endpoints`` expands environment
+variables (e.g. ``$HOME``) before resolving ``~`` to the user's home.
 
 See [`AGENTS.md`](AGENTS.md) for details on how we integrate LLMs and prompts.
 

--- a/llms.py
+++ b/llms.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import re
 from pathlib import Path
 from typing import List, Tuple
@@ -11,8 +12,9 @@ def get_llm_endpoints(path: str | Path | None = None) -> List[Tuple[str, str]]:
     Parameters
     ----------
     path: str | Path | None, optional
-        Optional path to ``llms.txt``. ``~`` expands to the user home
-        directory. Defaults to the copy beside this module.
+        Optional path to ``llms.txt``. Environment variables like ``$HOME``
+        are expanded, then ``~`` expands to the user home directory.
+        Defaults to the copy beside this module.
 
     Returns
     -------
@@ -31,7 +33,7 @@ def get_llm_endpoints(path: str | Path | None = None) -> List[Tuple[str, str]]:
     if path is None:
         llms_path = Path(__file__).with_name("llms.txt")
     else:
-        llms_path = Path(path).expanduser()
+        llms_path = Path(os.path.expandvars(path)).expanduser()
     try:
         lines = llms_path.read_text(encoding="utf-8").splitlines()
     except FileNotFoundError:

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -75,3 +75,13 @@ def test_get_llm_endpoints_allows_indented_bullets(tmp_path):
     )
     endpoints = llms.get_llm_endpoints(str(llms_file))
     assert endpoints == [("Example", "https://example.com")]
+
+
+def test_get_llm_endpoints_expands_env_vars(tmp_path, monkeypatch):
+    llms_file = tmp_path / "custom.txt"
+    llms_file.write_text(
+        "## LLM Endpoints\n- [foo](https://example.com)\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("SIGMA_LLM_DIR", str(tmp_path))
+    endpoints = dict(llms.get_llm_endpoints("$SIGMA_LLM_DIR/custom.txt"))
+    assert endpoints == {"foo": "https://example.com"}


### PR DESCRIPTION
## Summary
- expand $VARs in optional path to get_llm_endpoints
- document environment variable expansion
- test path expansion for environment variables

## Testing
- `pre-commit run --all-files`
- `make test`
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a00fc7cc64832fb546ccd7be89a7ba