### PR TITLE
Support '+' bullets in LLM endpoint parser

### DIFF
--- a/llms.py
+++ b/llms.py
@@ -21,7 +21,7 @@ def get_llm_endpoints(path: str | Path | None = None) -> List[Tuple[str, str]]:
 
     Notes
     -----
-    Only bullet links starting with ``-`` or ``*`` within the
+    Only bullet links starting with ``-``, ``*``, or ``+`` within the
     ``## LLM Endpoints`` section are parsed. The section heading is matched
     case-insensitively. URL schemes are also matched case-insensitively so
     ``HTTPS`` and ``https`` are treated the same. If the file does not exist
@@ -39,7 +39,7 @@ def get_llm_endpoints(path: str | Path | None = None) -> List[Tuple[str, str]]:
 
     # Only parse bullet links in the "## LLM Endpoints" section.
     pattern = re.compile(
-        r"^[\-*] \[(?P<name>[^\]]+)\]\((?P<url>https?://[^)]+)\)",
+        r"^[-*+] \[(?P<name>[^\]]+)\]\((?P<url>https?://[^)]+)\)",
         re.IGNORECASE,
     )
     endpoints: List[Tuple[str, str]] = []

--- a/llms.txt
+++ b/llms.txt
@@ -9,7 +9,7 @@
 - [CONTRIBUTING](CONTRIBUTING.md): contribution workflow
 
 ## LLM Endpoints
-# Parsed by llms.get_llm_endpoints (bullets may start with '-' or '*')
+# Parsed by llms.get_llm_endpoints (bullets may start with '-', '*', or '+')
 - [token.place](https://github.com/futuroptimist/token.place): default stateless API
 - [OpenRouter](https://openrouter.ai/): hosted aggregator of multiple models
 - [OpenAI API](https://platform.openai.com/): commercial chat models

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -58,6 +58,15 @@ def test_get_llm_endpoints_supports_star_bullets(tmp_path):
     assert endpoints == [("Example", "https://example.com")]
 
 
+def test_get_llm_endpoints_supports_plus_bullets(tmp_path):
+    llms_file = tmp_path / "custom.txt"
+    llms_file.write_text(
+        "## LLM Endpoints\n+ [Example](https://example.com)", encoding="utf-8"
+    )
+    endpoints = llms.get_llm_endpoints(str(llms_file))
+    assert endpoints == [("Example", "https://example.com")]
+
+
 def test_get_llm_endpoints_heading_case_insensitive(tmp_path):
     llms_file = tmp_path / "custom.txt"
     llms_file.write_text(


### PR DESCRIPTION
## Summary
- allow `+` bullet markers in `llms.get_llm_endpoints`
- document accepted markers in `llms.txt`
- test parsing of plus bullets

## Testing
- `pre-commit run --all-files`
- `make test`
- `bash scripts/checks.sh`
- `npm run lint` *(fails: Could not read package.json)*
- `npm run test:ci` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a00fc7cc64832fb546ccd7be89a7ba