### PR TITLE
🐛: ignore backslash bullets in llm endpoint parser

### DIFF
--- a/llms.py
+++ b/llms.py
@@ -39,7 +39,7 @@ def get_llm_endpoints(path: str | Path | None = None) -> List[Tuple[str, str]]:
 
     # Only parse bullet links in the "## LLM Endpoints" section.
     pattern = re.compile(
-        r"^[\-*] \[(?P<name>[^\]]+)\]\((?P<url>https?://[^)]+)\)",
+        r"^[-*] \[(?P<name>[^\]]+)\]\((?P<url>https?://[^)]+)\)",
         re.IGNORECASE,
     )
     endpoints: List[Tuple[str, str]] = []

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -58,6 +58,16 @@ def test_get_llm_endpoints_supports_star_bullets(tmp_path):
     assert endpoints == [("Example", "https://example.com")]
 
 
+def test_get_llm_endpoints_ignores_backslash_bullets(tmp_path):
+    llms_file = tmp_path / "custom.txt"
+    llms_file.write_text(
+        "## LLM Endpoints\n\\ [Ignored](https://example.com)",
+        encoding="utf-8",
+    )
+    endpoints = llms.get_llm_endpoints(str(llms_file))
+    assert endpoints == []
+
+
 def test_get_llm_endpoints_heading_case_insensitive(tmp_path):
     llms_file = tmp_path / "custom.txt"
     llms_file.write_text(


### PR DESCRIPTION
what: restrict regex to '-' and '*' bullets; add backslash test
why: backslash-prefixed lines were parsed as endpoints
how to test:
- pre-commit run --all-files
- make test
- bash scripts/checks.sh
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68a00fc7cc64832fb546ccd7be89a7ba