### PR TITLE
🐛 fix: validate non-numeric percentile inputs

### DIFF
--- a/sigma/utils.py
+++ b/sigma/utils.py
@@ -18,15 +18,18 @@ def percentile_rank(value: float, values: Iterable[float]) -> float:
 
     The percentile is computed using the "midrank" method: the percentage of
     entries less than ``value`` plus half of the entries equal to it. Raises
-    ``ValueError`` if ``values`` is empty or if any number is non-finite.
-    ``values`` may be any iterable and is materialized internally, so
-    generators are consumed only once.
+    ``ValueError`` if ``values`` is empty or if ``value`` or any element of
+    ``values`` is non-numeric or non-finite. ``values`` may be any iterable and
+    is materialized internally, so generators are consumed only once.
     """
     vals = list(values)
     if not vals:
         raise ValueError("values must be non-empty")
-    if not math.isfinite(value) or any(not math.isfinite(v) for v in vals):
-        raise ValueError("values must be finite numbers")
+    try:
+        if not math.isfinite(value) or any(not math.isfinite(v) for v in vals):
+            raise ValueError("values must be finite numbers")
+    except TypeError as exc:
+        raise ValueError("values must be finite numbers") from exc
 
     sorted_vals = sorted(vals)
     return _midrank(value, sorted_vals)
@@ -39,15 +42,18 @@ def average_percentile(values: Iterable[float]) -> float:
     than the value plus half of the entries equal to it. This "midrank" method
     avoids skewing the result when duplicates are present. The function returns
     the mean of these percentiles and raises ``ValueError`` if *values* is
-    empty or contains non-finite numbers such as ``NaN`` or ``inf``. ``values``
-    may be any iterable and is materialized internally, so generators are
-    consumed only once.
+    empty or contains non-numeric or non-finite numbers such as ``NaN`` or
+    ``inf``. ``values`` may be any iterable and is materialized internally, so
+    generators are consumed only once.
     """
     vals = list(values)
     if not vals:
         raise ValueError("values must be non-empty")
-    if any(not math.isfinite(v) for v in vals):
-        raise ValueError("values must be finite numbers")
+    try:
+        if any(not math.isfinite(v) for v in vals):
+            raise ValueError("values must be finite numbers")
+    except TypeError as exc:
+        raise ValueError("values must be finite numbers") from exc
 
     sorted_vals = sorted(vals)
     n = len(sorted_vals)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -32,6 +32,11 @@ def test_average_percentile_non_finite_raises():
         average_percentile([1.0, math.nan])
 
 
+def test_average_percentile_non_numeric_raises():
+    with pytest.raises(ValueError):
+        average_percentile([1.0, "a"])
+
+
 def test_percentile_rank_basic():
     values = [1, 2, 3]
     assert math.isclose(percentile_rank(2, values), 50.0, rel_tol=1e-9)
@@ -45,6 +50,16 @@ def test_percentile_rank_empty_list_raises():
 def test_percentile_rank_non_finite_raises():
     with pytest.raises(ValueError):
         percentile_rank(math.nan, [1.0])
+
+
+def test_percentile_rank_non_numeric_value_raises():
+    with pytest.raises(ValueError):
+        percentile_rank("a", [1.0])
+
+
+def test_percentile_rank_non_numeric_in_values_raises():
+    with pytest.raises(ValueError):
+        percentile_rank(1.0, [1.0, "a"])
 
 
 def test_percentile_rank_accepts_generators():


### PR DESCRIPTION
## Summary
- raise `ValueError` for non-numeric entries in percentile utilities
- test string handling in `average_percentile` and `percentile_rank`

## Testing
- `pre-commit run --all-files`
- `make test`
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a00fc7cc64832fb546ccd7be89a7ba