### PR TITLE
Add clamp utility function for value bounding

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,15 @@ from sigma.utils import percentile_rank
 print(percentile_rank(2, [1, 2, 3]))  # 50.0
 ```
 
+Use `clamp` to bound a value to an inclusive range:
+
+```python
+from sigma.utils import clamp
+
+print(clamp(5, 0, 10))   # 5
+print(clamp(15, 0, 10))  # 10
+```
+
 ## Roadmap
 
 - [ ] Breadboard MVP with a button toggling an LED

--- a/sigma/__init__.py
+++ b/sigma/__init__.py
@@ -1,5 +1,5 @@
 """Sigma utility package."""
 
-from .utils import average_percentile, percentile_rank
+from .utils import average_percentile, clamp, percentile_rank
 
-__all__ = ["average_percentile", "percentile_rank"]
+__all__ = ["average_percentile", "percentile_rank", "clamp"]

--- a/sigma/utils.py
+++ b/sigma/utils.py
@@ -53,3 +53,17 @@ def average_percentile(values: Iterable[float]) -> float:
     n = len(sorted_vals)
     total = sum(_midrank(v, sorted_vals) for v in vals)
     return total / n
+
+
+def clamp(value: float, lower: float, upper: float) -> float:
+    """Return ``value`` clamped to the inclusive range [``lower``, ``upper``].
+
+    Raises ``ValueError`` if the bounds are invalid or any argument is
+    non-finite. ``lower`` may equal ``upper``.
+    """
+
+    if any(not math.isfinite(v) for v in (value, lower, upper)):
+        raise ValueError("value and bounds must be finite numbers")
+    if lower > upper:
+        raise ValueError("lower bound must be <= upper bound")
+    return max(lower, min(value, upper))

--- a/tests/test_clamp.py
+++ b/tests/test_clamp.py
@@ -1,0 +1,31 @@
+import math
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from sigma.utils import clamp  # noqa: E402,E501
+
+
+def test_clamp_within_bounds():
+    assert clamp(5, 0, 10) == 5
+
+
+def test_clamp_below_bounds():
+    assert clamp(-1, 0, 10) == 0
+
+
+def test_clamp_above_bounds():
+    assert clamp(11, 0, 10) == 10
+
+
+def test_clamp_invalid_bounds():
+    with pytest.raises(ValueError):
+        clamp(1, 10, 0)
+
+
+def test_clamp_non_finite_raises():
+    with pytest.raises(ValueError):
+        clamp(math.nan, 0, 1)


### PR DESCRIPTION
## Summary
- add clamp() helper to bound numeric values
- document clamp in README
- test clamp behavior

## Testing
- `pre-commit run --all-files`
- `make test`
- `bash scripts/checks.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a00fcd2dd8832fac4310b0faf5acb2