### PR TITLE
🐛: allow extra spaces after bullet in LLM endpoint parser

### DIFF
--- a/llms.py
+++ b/llms.py
@@ -22,7 +22,8 @@ def get_llm_endpoints(path: str | Path | None = None) -> List[Tuple[str, str]]:
     Notes
     -----
     Only bullet links starting with ``-`` or ``*`` within the
-    ``## LLM Endpoints`` section are parsed. The section heading is matched
+    ``## LLM Endpoints`` section are parsed. Leading whitespace and multiple
+    spaces after the bullet are ignored. The section heading is matched
     case-insensitively. URL schemes are also matched case-insensitively so
     ``HTTPS`` and ``https`` are treated the same. If the file does not exist
     an empty list is returned instead of raising ``FileNotFoundError``.
@@ -37,9 +38,11 @@ def get_llm_endpoints(path: str | Path | None = None) -> List[Tuple[str, str]]:
     except FileNotFoundError:
         return []
 
-    # Only parse bullet links in the "## LLM Endpoints" section.
+    # Only parse bullet links in the "## LLM Endpoints" section. Allow any
+    # amount of whitespace after the bullet so lines like "-   [name](url)"
+    # are handled correctly.
     pattern = re.compile(
-        r"^[\-*] \[(?P<name>[^\]]+)\]\((?P<url>https?://[^)]+)\)",
+        r"^[\-*]\s+\[(?P<name>[^\]]+)\]\((?P<url>https?://[^)]+)\)",
         re.IGNORECASE,
     )
     endpoints: List[Tuple[str, str]] = []

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -75,3 +75,13 @@ def test_get_llm_endpoints_allows_indented_bullets(tmp_path):
     )
     endpoints = llms.get_llm_endpoints(str(llms_file))
     assert endpoints == [("Example", "https://example.com")]
+
+
+def test_get_llm_endpoints_allows_extra_spaces_after_bullet(tmp_path):
+    llms_file = tmp_path / "custom.txt"
+    llms_file.write_text(
+        "## LLM Endpoints\n-   [Example](https://example.com)",
+        encoding="utf-8",
+    )
+    endpoints = llms.get_llm_endpoints(str(llms_file))
+    assert endpoints == [("Example", "https://example.com")]


### PR DESCRIPTION
## Summary
- tolerate extra spaces after '-' or '*' when parsing `llms.txt`
- cover regression with a dedicated test

## Testing
- `pre-commit run --all-files`
- `make test`
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a00fcd2dd8832fac4310b0faf5acb2