### PR TITLE
🐛: clarify percentile_rank error message

### DIFF
--- a/sigma/utils.py
+++ b/sigma/utils.py
@@ -18,14 +18,16 @@ def percentile_rank(value: float, values: Iterable[float]) -> float:
 
     The percentile is computed using the "midrank" method: the percentage of
     entries less than ``value`` plus half of the entries equal to it. Raises
-    ``ValueError`` if ``values`` is empty or if any number is non-finite.
-    ``values`` may be any iterable and is materialized internally, so
-    generators are consumed only once.
+    ``ValueError`` if ``values`` is empty, ``value`` is not finite, or any
+    number in ``values`` is non-finite. ``values`` may be any iterable and is
+    materialized internally, so generators are consumed only once.
     """
     vals = list(values)
     if not vals:
         raise ValueError("values must be non-empty")
-    if not math.isfinite(value) or any(not math.isfinite(v) for v in vals):
+    if not math.isfinite(value):
+        raise ValueError("value must be a finite number")
+    if any(not math.isfinite(v) for v in vals):
         raise ValueError("values must be finite numbers")
 
     sorted_vals = sorted(vals)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -42,8 +42,8 @@ def test_percentile_rank_empty_list_raises():
         percentile_rank(1, [])
 
 
-def test_percentile_rank_non_finite_raises():
-    with pytest.raises(ValueError):
+def test_percentile_rank_non_finite_value_message():
+    with pytest.raises(ValueError, match="value must be a finite number"):
         percentile_rank(math.nan, [1.0])
 
 


### PR DESCRIPTION
## What
- differentiate error messages for non-finite value vs list in percentile_rank
- test error wording for non-finite percentile value

## Why
- previous message obscured whether value or list contained non-finite numbers

## How to Test
- `pre-commit run --all-files`
- `make test`
- `bash scripts/checks.sh`

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68a00fcd2dd8832fac4310b0faf5acb2