### PR TITLE
🧪: ensure percentile helpers work with generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ from sigma.utils import percentile_rank
 print(percentile_rank(2, [1, 2, 3]))  # 50.0
 ```
 
+Both `average_percentile` and `percentile_rank` accept any iterable, so generators work too.
+
 Use `clamp` to bound a value to an inclusive range:
 
 ```python

--- a/sigma/utils.py
+++ b/sigma/utils.py
@@ -56,7 +56,7 @@ def average_percentile(values: Iterable[float]) -> float:
         raise ValueError("values must be finite numbers") from exc
 
     sorted_vals = sorted(vals)
-    n = len(sorted_vals)
+    n = len(vals)
     total = sum(_midrank(v, sorted_vals) for v in vals)
     return total / n
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -37,6 +37,14 @@ def test_average_percentile_non_numeric_raises():
         average_percentile([1.0, "a"])
 
 
+def test_average_percentile_accepts_generators():
+    def gen():
+        for v in [1.0, 2.0, 3.0]:
+            yield v
+
+    assert math.isclose(average_percentile(gen()), 50.0, rel_tol=1e-9)
+
+
 def test_percentile_rank_basic():
     values = [1, 2, 3]
     assert math.isclose(percentile_rank(2, values), 50.0, rel_tol=1e-9)


### PR DESCRIPTION
what: document and test generator support for percentile helpers
why: clarify iterable use and simplify average_percentile length calc
how to test:
- pre-commit run --all-files
- make test
- bash scripts/checks.sh

Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68a57c68a440832f8ad159212f3dfed0