### PR TITLE
🐛: guard clamp against non-numeric values

### DIFF
--- a/sigma/utils.py
+++ b/sigma/utils.py
@@ -65,11 +65,14 @@ def clamp(value: float, lower: float, upper: float) -> float:
     """Return ``value`` clamped to the inclusive range [``lower``, ``upper``].
 
     Raises ``ValueError`` if the bounds are invalid or any argument is
-    non-finite. ``lower`` may equal ``upper``.
+    non-numeric or non-finite. ``lower`` may equal ``upper``.
     """
 
-    if any(not math.isfinite(v) for v in (value, lower, upper)):
-        raise ValueError("value and bounds must be finite numbers")
+    try:
+        if any(not math.isfinite(v) for v in (value, lower, upper)):
+            raise ValueError("value and bounds must be finite numbers")
+    except TypeError as exc:
+        raise ValueError("value and bounds must be finite numbers") from exc
     if lower > upper:
         raise ValueError("lower bound must be <= upper bound")
     return max(lower, min(value, upper))

--- a/tests/test_clamp.py
+++ b/tests/test_clamp.py
@@ -29,3 +29,8 @@ def test_clamp_invalid_bounds():
 def test_clamp_non_finite_raises():
     with pytest.raises(ValueError):
         clamp(math.nan, 0, 1)
+
+
+def test_clamp_non_numeric_raises():
+    with pytest.raises(ValueError):
+        clamp("a", 0, 1)


### PR DESCRIPTION
what: ensure clamp raises ValueError for non-numeric inputs; add regression test.
why: align error handling with other utility helpers.
how to test:
- pre-commit run --all-files
- make test
- bash scripts/checks.sh
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68a57c68a440832f8ad159212f3dfed0