### PR TITLE
docs: add prompt guides for docs and cleanup

### DIFF
--- a/docs/prompts-codex-cleanup.md
+++ b/docs/prompts-codex-cleanup.md
@@ -1,0 +1,29 @@
+---
+title: 'Codex Prompt Cleanup'
+slug: 'prompts-codex-cleanup'
+---
+
+# Codex Prompt Cleanup
+
+Use this prompt to remove obsolete or fulfilled prompt documents from Sigma.
+
+```
+SYSTEM:
+You are an automated contributor for the Sigma repository.
+
+PURPOSE:
+Keep prompt documentation current by deleting outdated items.
+
+CONTEXT:
+- Scan `docs/` for prompt files that no longer apply.
+- Remove sections or files that reference completed or removed features.
+- Run `pre-commit run --all-files` and `make test` before committing.
+
+REQUEST:
+1. Identify an obsolete prompt file or section.
+2. Delete it and update references as needed.
+3. Run the commands above to verify the cleanup.
+
+OUTPUT:
+A pull request that cleans up prompt docs with all checks passing.
+```

--- a/docs/prompts-codex-docs.md
+++ b/docs/prompts-codex-docs.md
@@ -1,0 +1,30 @@
+---
+title: 'Codex Docs Update Prompt'
+slug: 'prompts-codex-docs'
+---
+
+# Codex Docs Update Prompt
+
+Use this prompt to enhance or fix Sigma documentation.
+
+```
+SYSTEM:
+You are an automated contributor for the Sigma repository.
+
+PURPOSE:
+Improve documentation accuracy, links, or readability.
+
+CONTEXT:
+- Follow AGENTS.md instructions.
+- Run `pre-commit run --all-files` and `make test` before committing.
+- Keep lines within 100 characters.
+
+REQUEST:
+1. Identify outdated, unclear, or missing docs.
+2. Apply minimal edits to improve clarity.
+3. Update cross references or links when needed.
+4. Run the commands above to verify the changes.
+
+OUTPUT:
+A pull request summarizing documentation updates with passing checks.
+```


### PR DESCRIPTION
## Summary
- add Codex Docs Update Prompt for editing sigma documentation
- add Codex Prompt Cleanup guide to prune obsolete prompt files

## Testing
- `pre-commit run --all-files`
- `make test`
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a6cbb0a060832fb805ceb02f8a925e