### PR TITLE
🐛: allow subheadings in LLM endpoint parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ pre-commit install
 Helper scripts for STT, TTS and the LLM API live in `software/`.
 Configure the endpoint you want to use in [`llms.txt`](llms.txt).
 The parser matches the `## LLM Endpoints` heading case-insensitively,
-so `## llm endpoints` also works.
+so `## llm endpoints` also works. Subheadings (###) can group endpoints and are
+ignored by the parser.
 
 You can list the configured endpoints with:
 

--- a/llms.py
+++ b/llms.py
@@ -48,8 +48,13 @@ def get_llm_endpoints(path: str | Path | None = None) -> List[Tuple[str, str]]:
     in_section = False
     for line in lines:
         stripped = line.strip()
-        if stripped.startswith("##"):
-            in_section = stripped.casefold() == "## llm endpoints"
+        if stripped.startswith("# ") and not stripped.startswith("## "):
+            continue
+        heading = re.match(r"^(#+)\s", stripped)
+        if heading:
+            level = len(heading.group(1))
+            if level <= 2:
+                in_section = stripped.casefold() == "## llm endpoints"
             continue
         if not in_section:
             continue

--- a/llms.txt
+++ b/llms.txt
@@ -9,7 +9,8 @@
 - [CONTRIBUTING](CONTRIBUTING.md): contribution workflow
 
 ## LLM Endpoints
-# Parsed by llms.get_llm_endpoints (bullets may start with '-', '*', or '+')
+# Parsed by llms.get_llm_endpoints (bullets may start with '-', '*', or '+').
+# Subheadings (###) are ignored to allow grouping.
 - [token.place](https://github.com/futuroptimist/token.place): default stateless API
 - [OpenRouter](https://openrouter.ai/): hosted aggregator of multiple models
 - [OpenAI API](https://platform.openai.com/): commercial chat models

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -86,6 +86,16 @@ def test_get_llm_endpoints_allows_indented_bullets(tmp_path):
     assert endpoints == [("Example", "https://example.com")]
 
 
+def test_get_llm_endpoints_allows_subheadings(tmp_path):
+    llms_file = tmp_path / "custom.txt"
+    llms_file.write_text(
+        "## LLM Endpoints\n### Group A\n- [Example](https://example.com)",
+        encoding="utf-8",
+    )
+    endpoints = llms.get_llm_endpoints(str(llms_file))
+    assert endpoints == [("Example", "https://example.com")]
+
+
 def test_get_llm_endpoints_expands_env_vars(tmp_path, monkeypatch):
     llms_file = tmp_path / "custom.txt"
     llms_file.write_text(


### PR DESCRIPTION
## Summary
- handle markdown subheadings in llms.txt parser
- document subheading support
- cover parser with new test

## Testing
- `python -m pre_commit run --all-files`
- `make test`
- `bash scripts/checks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a92da29c30832fa848884bcbfa14e5