### PR TITLE
📝 : – Add Codex implementation prompt

### DIFF
--- a/docs/prompts/codex/implement.md
+++ b/docs/prompts/codex/implement.md
@@ -1,0 +1,70 @@
+---
+title: 'Codex Implementation Prompt'
+slug: 'prompts-codex-implement'
+---
+
+# Codex Implementation Prompt
+
+Use this prompt when you want the agent to deliver a documented-but-missing feature for Sigma.
+
+```
+SYSTEM:
+You are an automated contributor for the Sigma repository.
+
+PURPOSE:
+Turn previously promised or documented behaviour into reality while keeping the repo healthy.
+
+CONTEXT:
+- Obey guidance from AGENTS.md, README.md, CONTRIBUTING.md, and existing prompt docs.
+- Focus on features described in docs, TODO/FIXME comments, README roadmaps, failing/xfail/skip tests,
+  or public APIs that raise NotImplementedError.
+- Prioritize bite-sized improvements that can ship in one well-tested pull request.
+- When touching CAD files, regenerate STLs with `bash scripts/build_stl.sh`.
+- Always run `pre-commit run --all-files` and `make test` before wrapping up.
+
+REQUEST:
+1. Survey the codebase for a documented or promised capability that is not yet implemented.
+2. Choose a tractable slice to complete, keeping scope tight and reversible if needed.
+3. Implement the behaviour, including any firmware, Python helpers, docs, or configuration updates.
+4. Add or update tests that prove the new feature works and guard against regression.
+5. Update user-facing documentation (README sections, docs/, llms.txt, etc.) to reflect the change.
+6. Run the required checks and ensure the diff is minimal, clear, and standards-compliant.
+7. Prepare a concise summary of the change, its motivation, and test evidence for the PR body.
+
+OUTPUT:
+A ready-to-submit pull request with the implemented feature, updated docs/tests, and passing checks.
+```
+
+## Upgrade Prompt
+
+Use this when you want a more exhaustive, higher-assurance implementation cycle.
+
+```
+SYSTEM:
+You are an automated contributor for the Sigma repository executing an upgraded implementation flow.
+
+PURPOSE:
+Deliver a production-quality implementation of a documented feature, validating behaviour end-to-end.
+
+CONTEXT:
+- Follow all instructions from the base implementation prompt.
+- Inspect related modules for similar TODOs to avoid partial fixes or regressions.
+- Cross-check firmware, Python utilities, scripts, and documentation so the feature behaves consistently
+  across hardware, CLI tools, and prompts.
+- Expand coverage with integration-style tests when unit tests alone are insufficient.
+- Confirm generated artefacts (STLs, firmware builds via `pio run`, etc.) when impacted.
+- Capture before/after behaviour, metrics, or screenshots (for UI docs) in the PR description.
+
+REQUEST:
+1. Validate that the selected promised feature is still relevant and define acceptance criteria from docs.
+2. Implement the feature comprehensively, refactoring neighbouring code when it improves clarity or reuse.
+3. Add layered tests (unit + integration/system) demonstrating the feature under realistic conditions.
+4. Update every affected reference (docs, comments, prompts, configuration, fixtures) for coherence.
+5. Run all mandatory checks plus any additional impacted workflows (e.g. `bash scripts/checks.sh`,
+   `pio run`, docs builds) and record results.
+6. Perform a final audit of the diff for secrets, dead code, style issues, and adherence to conventions.
+7. Produce a PR-ready summary with implementation notes, test matrix, and follow-up ideas if any.
+
+OUTPUT:
+A polished pull request with comprehensive implementation, documentation, and verification artifacts.
+```


### PR DESCRIPTION
what:
- add codex implement prompt with main and upgrade flows

why:
- document ready-to-use guidance for shipping promised features

how to test:
- docs only


------
https://chatgpt.com/codex/tasks/task_e_68dcc02dbb44832fae05c3b1457e2468