### PR TITLE
✨ : – Allow whitespace-free bullets in LLM parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ Use the `llms.py` helper to manage language model endpoints.
 Configure LLM endpoints in [`llms.txt`](llms.txt), which the [`llms.py`](llms.py) helper parses.
 The parser matches the `## LLM Endpoints` heading case-insensitively,
 so `## llm endpoints` also works.
-Bullet links may start with `-`, `*`, or `+` and extra spaces after the bullet are ignored.
+Bullet links may start with `-`, `*`, or `+`; spacing after the bullet is optional, so
+`-[Example](https://example.com)` and `-   [Example](https://example.com)` both work.
 
 You can list the configured endpoints with:
 

--- a/llms.py
+++ b/llms.py
@@ -42,7 +42,7 @@ def get_llm_endpoints(path: str | Path | None = None) -> List[Tuple[str, str]]:
 
     # Only parse bullet links in the "## LLM Endpoints" section.
     pattern = re.compile(
-        r"^[-*+]\s+\[(?P<name>[^\]]+)\]\((?P<url>https?://[^)]+)\)",
+        r"^[-*+]\s*\[(?P<name>[^\]]+)\]\((?P<url>https?://[^)]+)\)",
         re.IGNORECASE,
     )
     endpoints: List[Tuple[str, str]] = []

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -91,6 +91,16 @@ def test_get_llm_endpoints_allows_multiple_spaces_after_bullet(tmp_path):
     assert endpoints == [("Example", "https://example.com")]
 
 
+def test_get_llm_endpoints_allows_no_space_after_bullet(tmp_path):
+    llms_file = tmp_path / "custom.txt"
+    llms_file.write_text(
+        "## LLM Endpoints\n-[Example](https://example.com)",
+        encoding="utf-8",
+    )
+    endpoints = llms.get_llm_endpoints(str(llms_file))
+    assert endpoints == [("Example", "https://example.com")]
+
+
 def test_get_llm_endpoints_expands_env_vars(tmp_path, monkeypatch):
     llms_file = tmp_path / "custom.txt"
     llms_file.write_text(


### PR DESCRIPTION
what: allow llms.get_llm_endpoints to parse bullets without spaces after the marker
why: docs promise any amount of whitespace before link text
how to test: pre-commit run --all-files && make test

------
https://chatgpt.com/codex/tasks/task_e_68dcc1e950e0832f80b3c2863976acc9