### PR TITLE
✨ : – Add interactive Sigma S1 3D viewer docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Sigma is an open-source ESP32 "AI pin" that lets you talk to a language model vi
 Hardware models for the enclosure live in [`hardware/cad`](hardware/cad) with
 STL exports in [`hardware/stl`](hardware/stl). A GitHub Actions workflow
 automatically regenerates the STL files whenever the SCAD sources change.
+Preview the enclosure interactively in the
+[Sigma S1 3D viewer](docs/sigma-s1-viewer.md).
 Regenerate STLs locally with:
 
 ```bash

--- a/docs/sigma-s1-assembly.md
+++ b/docs/sigma-s1-assembly.md
@@ -2,7 +2,8 @@
 
 This guide explains how to build the Sigma S1 push‑to‑talk device.
 The design uses an ESP32‑WROOM module, a microphone, speaker and
-an AA battery compartment housed in a 3D printed enclosure.
+an AA battery compartment housed in a 3D printed enclosure. For a
+360° view of the case, open the [Sigma S1 3D viewer](sigma-s1-viewer.md).
 
 The case also features a small lanyard hole for attaching a strap; the hole is 10 mm in diameter.
 
@@ -52,6 +53,3 @@ the side openings before closing the shell.
 3. Place the ESP32 into the printed case.
 4. Insert the AA holder and feed its leads to the module.
 5. Close the enclosure with small screws or glue as preferred.
-
-A future update will include a 3D viewer so you can inspect the model
-right from the repository.

--- a/docs/sigma-s1-viewer.md
+++ b/docs/sigma-s1-viewer.md
@@ -1,0 +1,22 @@
+# Sigma S1 3D Viewer
+
+Inspect the Sigma S1 enclosure directly in your browser using the interactive
+viewer below. The embedded component renders the STL exported from the
+OpenSCAD source in `hardware/cad/`.
+
+<script type="module"
+        src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js">
+</script>
+
+<model-viewer src="../hardware/stl/sigma-s1-enclosure.stl"
+              alt="Sigma S1 enclosure"
+              camera-controls
+              auto-rotate
+              ar
+              style="width: 100%; height: 500px; background-color: #f4f4f4;">
+  Loading 3D model...
+</model-viewer>
+
+The viewer supports touch and mouse gestures for orbiting, zooming, and
+panning. Use the toolbar buttons that appear on hover to reset the camera or
+switch between interaction modes.

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -7,7 +7,8 @@ dimensions as needed.
 The enclosure includes cutouts for the button, microphone, speaker, battery,
 USB-C port, a small lanyard hole for attaching a strap, and a 5 mm status LED
 opening. The lanyard hole measures 12 mm in diameter and sits 6 mm from the left
-edge. The USB-C cutout is 14 mm wide for improved cable clearance.
+edge. The USB-C cutout is 14 mm wide for improved cable clearance. You can
+preview the enclosure in the [Sigma S1 3D viewer](../docs/sigma-s1-viewer.md).
 
 - `cad/` – OpenSCAD models for 3D printing
 - `stl/` – auto-generated STL exports

--- a/llms.txt
+++ b/llms.txt
@@ -6,6 +6,7 @@
 - [README](README.md): setup and roadmap
 - [AGENTS](AGENTS.md): guidelines for AI helpers
 - [docs/sigma-s1-assembly.md](docs/sigma-s1-assembly.md): hardware assembly
+- [docs/sigma-s1-viewer.md](docs/sigma-s1-viewer.md): interactive 3D enclosure preview
 - [CONTRIBUTING](CONTRIBUTING.md): contribution workflow
 
 ## LLM Endpoints

--- a/tests/test_docs_viewer.py
+++ b/tests/test_docs_viewer.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+
+def test_sigma_s1_viewer_exists_and_references_stl():
+    viewer_doc = Path("docs/sigma-s1-viewer.md")
+    stl_path = Path("hardware/stl/sigma-s1-enclosure.stl")
+
+    assert viewer_doc.is_file(), "3D viewer documentation is missing"
+    assert stl_path.is_file(), "STL asset referenced by the viewer is missing"
+
+    content = viewer_doc.read_text(encoding="utf-8")
+    assert "<model-viewer" in content
+    assert "hardware/stl/sigma-s1-enclosure.stl" in content
+    assert "model-viewer.min.js" in content


### PR DESCRIPTION
what: ship a model-viewer page and cross-link docs for the Sigma S1 enclosure
why: deliver the documented promise of an in-repo 3d viewer experience
how to test: pre-commit run --all-files && make test

------
https://chatgpt.com/codex/tasks/task_e_68dcd44d0f4c832f85ae054548f1a51c