### PR TITLE
✨ Accept Path arguments in get_llm_endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ python -m llms
 If `llms.txt` is missing the command prints nothing and exits without error. The helper
 locates `llms.txt` relative to its own file, so you can run it from any working
 directory. The optional path argument to ``llms.get_llm_endpoints`` expands environment
-variables (e.g. ``$HOME``) before resolving ``~`` to the user's home.
+variables (e.g. ``$HOME``) before resolving ``~`` to the user's home, and accepts either
+string paths or ``pathlib.Path`` objects.
 
 See [`AGENTS.md`](AGENTS.md) for details on how we integrate LLMs and prompts.
 

--- a/docs/llms-guide.md
+++ b/docs/llms-guide.md
@@ -23,4 +23,5 @@ for name, url in get_llm_endpoints():
 
 The helper resolves `llms.txt` relative to its own file, so it works from
 any working directory. The optional path argument expands environment
-variables (e.g. `$HOME`) before resolving `~` to your home directory.
+variables (e.g. `$HOME`) before resolving `~` to your home directory and can
+be a `str` or `pathlib.Path`.

--- a/llms.py
+++ b/llms.py
@@ -34,7 +34,8 @@ def get_llm_endpoints(path: str | Path | None = None) -> List[Tuple[str, str]]:
     if path is None:
         llms_path = Path(__file__).with_name("llms.txt")
     else:
-        llms_path = Path(os.path.expandvars(path)).expanduser()
+        raw_path = os.fspath(path)
+        llms_path = Path(os.path.expandvars(raw_path)).expanduser()
     try:
         lines = llms_path.read_text(encoding="utf-8").splitlines()
     except FileNotFoundError:

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -109,3 +109,13 @@ def test_get_llm_endpoints_expands_env_vars(tmp_path, monkeypatch):
     monkeypatch.setenv("SIGMA_LLM_DIR", str(tmp_path))
     endpoints = dict(llms.get_llm_endpoints("$SIGMA_LLM_DIR/custom.txt"))
     assert endpoints == {"foo": "https://example.com"}
+
+
+def test_get_llm_endpoints_accepts_path_objects(tmp_path):
+    llms_file = tmp_path / "custom.txt"
+    llms_file.write_text(
+        "## LLM Endpoints\n- [Example](https://example.com)",
+        encoding="utf-8",
+    )
+    endpoints = llms.get_llm_endpoints(llms_file)
+    assert endpoints == [("Example", "https://example.com")]


### PR DESCRIPTION
what: allow get_llm_endpoints to accept pathlib.Path inputs
why: match the documented Path support for custom llms.txt locations
how to test: pre-commit run --all-files && make test

Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68dcd44d0f4c832f85ae054548f1a51c