### PR TITLE
Handle LLM endpoint headings with trailing hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Helper scripts live in [`scripts/`](scripts/) and LLM helpers in [`llms.py`](llm
 Use the `llms.py` helper to manage language model endpoints.
 Configure LLM endpoints in [`llms.txt`](llms.txt), which the [`llms.py`](llms.py) helper parses.
 The parser matches the `## LLM Endpoints` heading case-insensitively,
-so `## llm endpoints` also works.
+so `## llm endpoints` also works. Closing `#` characters are ignored,
+so `## LLM Endpoints ##` is treated the same way.
 Bullet links may start with `-`, `*`, or `+`; spacing after the bullet is optional, so
 `-[Example](https://example.com)` and `-   [Example](https://example.com)` both work.
 

--- a/docs/llms-guide.md
+++ b/docs/llms-guide.md
@@ -2,7 +2,8 @@
 
 `llms.py` parses `llms.txt` to discover available language model endpoints.
 The `llms.txt` file uses Markdown bullet lists under the `## LLM Endpoints`
-heading; entries can start with `-`, `*`, or `+`.
+heading; entries can start with `-`, `*`, or `+`. Trailing `#` characters after
+the heading text are ignored, so `## LLM Endpoints ##` is also recognised.
 
 ## Listing Endpoints
 

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -71,6 +71,16 @@ def test_get_llm_endpoints_heading_case_insensitive(tmp_path):
     assert "Example" in endpoints
 
 
+def test_get_llm_endpoints_heading_allows_closing_hashes(tmp_path):
+    llms_file = tmp_path / "custom.txt"
+    llms_file.write_text(
+        "## LLM Endpoints ##\n- [Example](https://example.com)",
+        encoding="utf-8",
+    )
+    endpoints = dict(llms.get_llm_endpoints(str(llms_file)))
+    assert endpoints == {"Example": "https://example.com"}
+
+
 def test_get_llm_endpoints_allows_indented_bullets(tmp_path):
     llms_file = tmp_path / "custom.txt"
     llms_file.write_text(


### PR DESCRIPTION
what: allow get_llm_endpoints to parse headings with trailing '#'
why: markdown headings sometimes include closing '#' characters
how to test: pre-commit run --all-files; make test

------
https://chatgpt.com/codex/tasks/task_e_68de05308b98832f8109306f30803c9e