### PR TITLE
✨ : – Respect top-level headings when parsing endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ so `## llm endpoints` also works. Closing `#` characters are ignored,
 so `## LLM Endpoints ##` is treated the same way.
 Bullet links may start with `-`, `*`, or `+`; spacing after the bullet is optional, so
 `-[Example](https://example.com)` and `-   [Example](https://example.com)` both work.
+Single-`#` comment lines are allowed before the list begins, but once endpoints appear a
+new single-`#` heading ends the section the same way any `##` heading does.
 
 You can list the configured endpoints with:
 

--- a/docs/llms-guide.md
+++ b/docs/llms-guide.md
@@ -4,6 +4,9 @@
 The `llms.txt` file uses Markdown bullet lists under the `## LLM Endpoints`
 heading; entries can start with `-`, `*`, or `+`. Trailing `#` characters after
 the heading text are ignored, so `## LLM Endpoints ##` is also recognised.
+Comments that start with a single `#` may appear before the list, but once an
+endpoint has been parsed another single-`#` heading terminates the section just
+like a `##` heading.
 
 ## Listing Endpoints
 

--- a/llms.py
+++ b/llms.py
@@ -50,10 +50,14 @@ def get_llm_endpoints(path: str | Path | None = None) -> List[Tuple[str, str]]:
     )
     endpoints: List[Tuple[str, str]] = []
     in_section = False
+    section_has_entry = False
     heading_pattern = re.compile(r"^(#+)\s*(.*?)\s*#*\s*$")
     for line in lines:
         stripped = line.strip()
         if stripped.startswith("#") and not stripped.startswith("##"):
+            if in_section and section_has_entry:
+                in_section = False
+                section_has_entry = False
             continue
         heading = heading_pattern.match(stripped)
         if heading:
@@ -61,12 +65,14 @@ def get_llm_endpoints(path: str | Path | None = None) -> List[Tuple[str, str]]:
             if level <= 2:
                 title = heading.group(2).strip()
                 in_section = title.casefold() == "llm endpoints"
+                section_has_entry = False
             continue
         if not in_section:
             continue
         match = pattern.match(stripped)
         if match:
             endpoints.append((match.group("name"), match.group("url")))
+            section_has_entry = True
     return endpoints
 
 

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -129,3 +129,20 @@ def test_get_llm_endpoints_accepts_path_objects(tmp_path):
     )
     endpoints = llms.get_llm_endpoints(llms_file)
     assert endpoints == [("Example", "https://example.com")]
+
+
+def test_get_llm_endpoints_stops_at_top_level_heading(tmp_path):
+    llms_file = tmp_path / "custom.txt"
+    llms_file.write_text(
+        (
+            "# Title\n"
+            "## LLM Endpoints\n"
+            "# Comment about the list\n"
+            "- [Example](https://example.com)\n"
+            "# Another Section\n"
+            "- [Ignored](https://ignored.example.com)\n"
+        ),
+        encoding="utf-8",
+    )
+    endpoints = llms.get_llm_endpoints(llms_file)
+    assert endpoints == [("Example", "https://example.com")]


### PR DESCRIPTION
what: stop llms.get_llm_endpoints parsing once a single-# heading
  appears after list entries and document the behaviour
why: keep markdown comments before the list while preventing later
  sections from being misclassified as endpoints
how to test: pre-commit run --all-files; make test

------
https://chatgpt.com/codex/tasks/task_e_68dec0808d74832fb3bb26cf66ed57d4