### PR TITLE
✨ : add LLM endpoint resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ Bullet links may start with `-`, `*`, or `+`; spacing after the bullet is option
 Single-`#` comment lines are allowed before the list begins, but once endpoints appear a
 new single-`#` heading ends the section the same way any `##` heading does.
 
+Select a specific endpoint with `resolve_llm_endpoint`:
+
+```python
+from llms import resolve_llm_endpoint
+
+name, url = resolve_llm_endpoint()  # first entry by default
+name, url = resolve_llm_endpoint("OpenRouter")  # case-insensitive lookup
+```
+
+Set the `SIGMA_DEFAULT_LLM` environment variable to override the default without
+changing code; the resolver raises an error if the variable references an unknown entry.
+
 You can list the configured endpoints with:
 
 ```bash

--- a/docs/llms-guide.md
+++ b/docs/llms-guide.md
@@ -29,3 +29,18 @@ The helper resolves `llms.txt` relative to its own file, so it works from
 any working directory. The optional path argument expands environment
 variables (e.g. `$HOME`) before resolving `~` to your home directory and can
 be a `str` or `pathlib.Path`.
+
+## Selecting a Default Endpoint
+
+Use `resolve_llm_endpoint` to choose a specific entry:
+
+```python
+from llms import resolve_llm_endpoint
+
+name, url = resolve_llm_endpoint()  # defaults to the first configured entry
+name, url = resolve_llm_endpoint("OpenRouter")  # case-insensitive lookup
+```
+
+Set the `SIGMA_DEFAULT_LLM` environment variable to change the default without
+modifying code. The resolver raises an error if the variable references an
+unknown endpoint or if `llms.txt` does not list any entries.

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -146,3 +146,71 @@ def test_get_llm_endpoints_stops_at_top_level_heading(tmp_path):
     )
     endpoints = llms.get_llm_endpoints(llms_file)
     assert endpoints == [("Example", "https://example.com")]
+
+
+def test_resolve_llm_endpoint_defaults_to_first_entry():
+    expected = llms.get_llm_endpoints()[0]
+    assert llms.resolve_llm_endpoint() == expected
+
+
+def test_resolve_llm_endpoint_respects_explicit_name(tmp_path):
+    llms_file = tmp_path / "custom.txt"
+    llms_file.write_text(
+        (
+            "## LLM Endpoints\n"
+            "- [Alpha](https://alpha.example.com)\n"
+            "- [Beta](https://beta.example.com)\n"
+        ),
+        encoding="utf-8",
+    )
+    name, url = llms.resolve_llm_endpoint("beta", path=llms_file)
+    assert name == "Beta"
+    assert url == "https://beta.example.com"
+
+
+def test_resolve_llm_endpoint_respects_env_variable(tmp_path, monkeypatch):
+    llms_file = tmp_path / "custom.txt"
+    llms_file.write_text(
+        (
+            "## LLM Endpoints\n"
+            "- [First](https://first.example.com)\n"
+            "- [Second](https://second.example.com)\n"
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("SIGMA_DEFAULT_LLM", "second")
+    assert llms.resolve_llm_endpoint(path=llms_file) == (
+        "Second",
+        "https://second.example.com",
+    )
+
+
+def test_resolve_llm_endpoint_unknown_name_raises(tmp_path):
+    llms_file = tmp_path / "custom.txt"
+    llms_file.write_text(
+        "## LLM Endpoints\n- [Alpha](https://alpha.example.com)",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="Unknown LLM endpoint"):
+        llms.resolve_llm_endpoint("gamma", path=llms_file)
+
+
+def test_resolve_llm_endpoint_invalid_env_raises(tmp_path, monkeypatch):
+    llms_file = tmp_path / "custom.txt"
+    llms_file.write_text(
+        "## LLM Endpoints\n- [Alpha](https://alpha.example.com)",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("SIGMA_DEFAULT_LLM", "missing")
+    with pytest.raises(RuntimeError, match="SIGMA_DEFAULT_LLM"):
+        llms.resolve_llm_endpoint(path=llms_file)
+
+
+def test_resolve_llm_endpoint_no_entries(tmp_path):
+    llms_file = tmp_path / "custom.txt"
+    llms_file.write_text("## LLM Endpoints\n", encoding="utf-8")
+    with pytest.raises(
+        RuntimeError,
+        match="does not define any LLM endpoints",
+    ):
+        llms.resolve_llm_endpoint(path=llms_file)


### PR DESCRIPTION
what: add resolve_llm_endpoint helper and env override support
why: let callers pick default endpoints without manual filtering
how to test: pre-commit run --all-files; make test
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68df7da16e80832fb596d0eb99d2f029