### PR TITLE
✨ : Handle parentheses in LLM endpoint URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ so `## llm endpoints` also works. Closing `#` characters are ignored,
 so `## LLM Endpoints ##` is treated the same way.
 Bullet links may start with `-`, `*`, or `+`; spacing after the bullet is optional, so
 `-[Example](https://example.com)` and `-   [Example](https://example.com)` both work.
+URLs may include balanced parentheses in the link target and are preserved as written.
 Single-`#` comment lines are allowed before the list begins, but once endpoints appear a
 new single-`#` heading ends the section the same way any `##` heading does.
 

--- a/docs/llms-guide.md
+++ b/docs/llms-guide.md
@@ -4,6 +4,8 @@
 The `llms.txt` file uses Markdown bullet lists under the `## LLM Endpoints`
 heading; entries can start with `-`, `*`, or `+`. Trailing `#` characters after
 the heading text are ignored, so `## LLM Endpoints ##` is also recognised.
+URLs may include balanced parentheses inside the link target; the parser keeps
+them intact when returning entries.
 Comments that start with a single `#` may appear before the list, but once an
 endpoint has been parsed another single-`#` heading terminates the section just
 like a `##` heading.

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -112,6 +112,20 @@ def test_get_llm_endpoints_allows_no_space_after_bullet(tmp_path):
     assert endpoints == [("Example", "https://example.com")]
 
 
+def test_get_llm_endpoints_allows_parentheses_in_url(tmp_path):
+    llms_file = tmp_path / "custom.txt"
+    llms_file.write_text(
+        (
+            "## LLM Endpoints\n"
+            "- [Example](https://example.com/path_(test)/resource)\n"
+        ),
+        encoding="utf-8",
+    )
+    endpoints = llms.get_llm_endpoints(str(llms_file))
+    expected_url = "https://example.com/path_(test)/resource"
+    assert endpoints == [("Example", expected_url)]
+
+
 def test_get_llm_endpoints_expands_env_vars(tmp_path, monkeypatch):
     llms_file = tmp_path / "custom.txt"
     llms_file.write_text(


### PR DESCRIPTION
what: allow llms parser to keep URLs with balanced parentheses
why: llms.txt uses Markdown links where parentheses are valid targets
how to test: pre-commit run --all-files && make test

------
https://chatgpt.com/codex/tasks/task_e_68e1b6946300832fabfd2d7aa0c10bcb