### PR TITLE
Handle whitespace in SIGMA_DEFAULT_LLM selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ name, url = resolve_llm_endpoint("OpenRouter")  # case-insensitive lookup
 ```
 
 Set the `SIGMA_DEFAULT_LLM` environment variable to override the default without
-changing code; the resolver raises an error if the variable references an unknown entry.
+changing code; surrounding whitespace is ignored, and the resolver raises an error if the
+variable is empty or references an unknown entry.
 
 You can list the configured endpoints with:
 

--- a/docs/llms-guide.md
+++ b/docs/llms-guide.md
@@ -49,5 +49,6 @@ name, url = resolve_llm_endpoint("OpenRouter")  # case-insensitive lookup
 ```
 
 Set the `SIGMA_DEFAULT_LLM` environment variable to change the default without
-modifying code. The resolver raises an error if the variable references an
-unknown endpoint or if `llms.txt` does not list any entries.
+modifying code. Leading and trailing whitespace is ignored, and the resolver
+raises an error if the variable is empty, references an unknown endpoint, or if
+`llms.txt` does not list any entries.

--- a/llms.py
+++ b/llms.py
@@ -86,15 +86,21 @@ def resolve_llm_endpoint(
         )
         raise ValueError(message)
 
-    env_preference = os.getenv("SIGMA_DEFAULT_LLM")
-    if env_preference:
-        candidate = lookup.get(env_preference.casefold())
+    env_preference_raw = os.getenv("SIGMA_DEFAULT_LLM")
+    if env_preference_raw is not None:
+        normalized = env_preference_raw.strip()
+        if not normalized:
+            raise RuntimeError(
+                "Environment variable SIGMA_DEFAULT_LLM is set but empty."
+            )
+        candidate = lookup.get(normalized.casefold())
         if candidate is not None:
             return candidate
         available = _format_available()
         message = (
             "Environment variable SIGMA_DEFAULT_LLM is set to "
-            f"{env_preference!r}, but no matching endpoint was found. "
+            f"{env_preference_raw!r} (normalized to {normalized!r}), but no "
+            "matching endpoint was found. "
             f"Available endpoints: {available}"
         )
         raise RuntimeError(message)

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -207,6 +207,34 @@ def test_resolve_llm_endpoint_invalid_env_raises(tmp_path, monkeypatch):
         llms.resolve_llm_endpoint(path=llms_file)
 
 
+def test_resolve_llm_endpoint_env_strips_whitespace(tmp_path, monkeypatch):
+    llms_file = tmp_path / "custom.txt"
+    llms_file.write_text(
+        (
+            "## LLM Endpoints\n"
+            "- [Alpha](https://alpha.example.com)\n"
+            "- [Beta](https://beta.example.com)\n"
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("SIGMA_DEFAULT_LLM", "  beta  ")
+    assert llms.resolve_llm_endpoint(path=llms_file) == (
+        "Beta",
+        "https://beta.example.com",
+    )
+
+
+def test_resolve_llm_endpoint_empty_env_raises(tmp_path, monkeypatch):
+    llms_file = tmp_path / "custom.txt"
+    llms_file.write_text(
+        "## LLM Endpoints\n- [Alpha](https://alpha.example.com)",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("SIGMA_DEFAULT_LLM", "   ")
+    with pytest.raises(RuntimeError, match="set but empty"):
+        llms.resolve_llm_endpoint(path=llms_file)
+
+
 def test_resolve_llm_endpoint_no_entries(tmp_path):
     llms_file = tmp_path / "custom.txt"
     llms_file.write_text("## LLM Endpoints\n", encoding="utf-8")


### PR DESCRIPTION
## Summary
- trim SIGMA_DEFAULT_LLM and reject empty values in resolver
- add regression tests and document stricter environment handling

## Testing
- python -m pre_commit run --all-files
- make test

------
https://chatgpt.com/codex/tasks/task_e_68e1b6946300832fabfd2d7aa0c10bcb