### PR TITLE
✨ : add CLI resolution for llms endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,13 @@ You can list the configured endpoints with:
 python -m llms
 ```
 
+Resolve a single endpoint (respecting ``SIGMA_DEFAULT_LLM`` when set) with:
+
+```bash
+python -m llms --resolve
+python -m llms --resolve --name OpenRouter
+```
+
 When you're working outside the repository root, use the helper script which
 bootstraps ``PYTHONPATH`` before calling the module:
 

--- a/docs/llms-guide.md
+++ b/docs/llms-guide.md
@@ -32,6 +32,14 @@ variables and ``~`` in the same order as calling ``llms.get_llm_endpoints``:
 python -m llms $HOME/custom-llms.txt
 ```
 
+Resolve a single endpoint from the command line (respecting
+``SIGMA_DEFAULT_LLM`` unless ``--name`` is supplied):
+
+```bash
+python -m llms --resolve
+python -m llms --resolve --name OpenRouter
+```
+
 You can also import the helper in Python:
 
 ```python


### PR DESCRIPTION
what
- add --resolve/--name switches so `python -m llms` can resolve a single
  endpoint
- document the new CLI flow and extend coverage for the resolver path

why
- the docs describe resolving endpoints but the CLI only listed them, making
  single-endpoint lookups less convenient

how to test
- pre-commit run --all-files
- make test

------
https://chatgpt.com/codex/tasks/task_e_68e3134ada38832f92e652c3181b231f