### PR TITLE
Add HTTP client helper for querying LLM endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,39 @@ print(clamp(15, 0, 10))  # 10
 print(clamp(Decimal("1.5"), Decimal("0"), Decimal("2")))  # Decimal('1.5')
 ```
 
+### Querying an LLM
+
+Use `sigma.query_llm` to send a prompt to the currently configured LLM endpoint.
+The helper resolves the endpoint via `llms.resolve_llm_endpoint`, sends a JSON
+payload containing the prompt, and extracts a sensible reply from common JSON
+shapes (`{"response": ...}`, `{"text": ...}`, or OpenAI-style
+`{"choices": [{"message": {"content": ...}}]}`). Plain-text responses are
+returned as-is.
+
+```python
+from sigma import query_llm
+
+result = query_llm("Tell me a joke")
+print(result.text)
+```
+
+Supply `extra_payload` to add provider-specific options without clobbering the
+prompt, and pass `name=` to target a specific endpoint:
+
+```python
+result = query_llm(
+    "Summarise Sigma in one sentence.",
+    name="OpenRouter",
+    extra_payload={"temperature": 0.2},
+)
+print(result.status)  # HTTP status code
+print(result.json())  # Full JSON payload when available
+```
+
+The helper raises `RuntimeError` if the endpoint does not speak HTTP(S) or if a
+JSON reply lacks an obvious text field, making integration failures easier to
+spot.
+
 ## Roadmap
 
 - [ ] Breadboard MVP with a button toggling an LED

--- a/docs/llms-guide.md
+++ b/docs/llms-guide.md
@@ -61,3 +61,12 @@ Set the `SIGMA_DEFAULT_LLM` environment variable to change the default without
 modifying code. Leading and trailing whitespace is ignored, and the resolver
 raises an error if the variable is empty, references an unknown endpoint, or if
 `llms.txt` does not list any entries.
+
+## Issuing a Request
+
+The `sigma.query_llm` helper wraps `resolve_llm_endpoint` and submits a JSON
+payload to the selected HTTP(S) endpoint. It accepts an optional
+`extra_payload` mapping for provider-specific parameters and extracts a reply
+from common response shapes (`response`, `text`, or the first
+`choices[].message.content`). Plain-text responses are returned unchanged, and a
+`RuntimeError` is raised if a JSON response cannot be interpreted.

--- a/sigma/__init__.py
+++ b/sigma/__init__.py
@@ -1,5 +1,12 @@
 """Sigma utility package."""
 
+from .llm_client import LLMResponse, query_llm
 from .utils import average_percentile, clamp, percentile_rank
 
-__all__ = ["average_percentile", "percentile_rank", "clamp"]
+__all__ = [
+    "average_percentile",
+    "percentile_rank",
+    "clamp",
+    "query_llm",
+    "LLMResponse",
+]

--- a/sigma/llm_client.py
+++ b/sigma/llm_client.py
@@ -1,0 +1,181 @@
+"""Helpers for querying language model endpoints."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from typing import Any, Mapping, MutableMapping
+from urllib import error, parse, request
+
+from llms import resolve_llm_endpoint
+
+__all__ = ["LLMResponse", "query_llm"]
+
+
+@dataclass(frozen=True)
+class LLMResponse:
+    """Response returned by :func:`query_llm`."""
+
+    name: str
+    url: str
+    text: str
+    status: int
+    headers: Mapping[str, str]
+    raw: bytes
+    encoding: str
+
+    def json(self) -> Any:
+        """Return the decoded JSON payload from the response."""
+
+        if not self.raw:
+            return None
+        try:
+            decoded = self.raw.decode(self.encoding)
+        except UnicodeDecodeError as exc:  # pragma: no cover
+            message = "Response payload is not valid UTF-8 JSON"
+            raise ValueError(message) from exc
+        try:
+            return json.loads(decoded)
+        except json.JSONDecodeError as exc:
+            raise ValueError("Response payload is not valid JSON") from exc
+
+
+_SUPPORTED_SCHEMES = {"http", "https"}
+_JSON_CONTENT_TYPES = {"application/json", "text/json"}
+
+
+def _ensure_prompt(prompt: str) -> str:
+    if not isinstance(prompt, str):
+        raise TypeError("prompt must be a string")
+    stripped = prompt.strip()
+    if not stripped:
+        raise ValueError("prompt must be a non-empty string")
+    return prompt
+
+
+def _prepare_payload(
+    prompt: str,
+    extra_payload: Mapping[str, Any] | None,
+) -> bytes:
+    if extra_payload is not None:
+        if not isinstance(extra_payload, Mapping):
+            raise TypeError("extra_payload must be a mapping if provided")
+        if "prompt" in extra_payload:
+            message = "extra_payload must not override the prompt field"
+            raise ValueError(message)
+        payload: MutableMapping[str, Any] = {"prompt": prompt}
+        payload.update(extra_payload)
+    else:
+        payload = {"prompt": prompt}
+    try:
+        return json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        message = "extra_payload contains non-serialisable values"
+        raise TypeError(message) from exc
+
+
+def _extract_text(data: Any) -> str | None:
+    if isinstance(data, str):
+        return data
+    if isinstance(data, Mapping):
+        for key in ("response", "text"):
+            value = data.get(key)
+            if isinstance(value, str):
+                return value
+        choices = data.get("choices")
+        if isinstance(choices, list):
+            for choice in choices:
+                if not isinstance(choice, Mapping):
+                    continue
+                text_value = choice.get("text")
+                if isinstance(text_value, str):
+                    return text_value
+                message = choice.get("message")
+                if isinstance(message, Mapping):
+                    content = message.get("content")
+                    if isinstance(content, str):
+                        return content
+        data_field = data.get("data")
+        if data_field is not None:
+            nested = _extract_text(data_field)
+            if isinstance(nested, str):
+                return nested
+    if isinstance(data, list):
+        for item in data:
+            text_value = _extract_text(item)
+            if isinstance(text_value, str):
+                return text_value
+    return None
+
+
+def query_llm(
+    prompt: str,
+    *,
+    name: str | None = None,
+    path: str | os.PathLike[str] | None = None,
+    timeout: float = 10.0,
+    extra_payload: Mapping[str, Any] | None = None,
+) -> LLMResponse:
+    """Send *prompt* to an HTTP LLM endpoint and return the parsed response."""
+
+    prompt = _ensure_prompt(prompt)
+    display_name, url = resolve_llm_endpoint(name, path=path)
+    parsed = parse.urlparse(url)
+    if parsed.scheme.lower() not in _SUPPORTED_SCHEMES:
+        message = (
+            f"LLM endpoint '{display_name}' uses unsupported scheme "
+            f"'{parsed.scheme}'"
+        )
+        raise RuntimeError(message)
+
+    body = _prepare_payload(prompt, extra_payload)
+    headers = {
+        "Content-Type": "application/json; charset=utf-8",
+        "Accept": "application/json, text/plain",
+    }
+    req = request.Request(url, data=body, headers=headers, method="POST")
+    try:
+        with request.urlopen(req, timeout=timeout) as response:
+            raw = response.read()
+            encoding = response.headers.get_content_charset("utf-8")
+            content_type = response.headers.get_content_type()
+            text_body = raw.decode(encoding, errors="replace")
+            parsed_json: Any | None = None
+            if raw:
+                stripped = text_body.lstrip()
+                json_like = stripped.startswith(("{", "["))
+                if content_type in _JSON_CONTENT_TYPES or json_like:
+                    try:
+                        parsed_json = json.loads(text_body)
+                    except json.JSONDecodeError:
+                        parsed_json = None
+            if parsed_json is not None:
+                text_value = _extract_text(parsed_json)
+                if text_value is None:
+                    raise RuntimeError(
+                        "LLM endpoint "
+                        f"'{display_name}' returned JSON without a recognised "
+                        "text field"
+                    )
+            else:
+                text_value = text_body
+            return LLMResponse(
+                name=display_name,
+                url=url,
+                text=text_value,
+                status=response.status,
+                headers=dict(response.headers.items()),
+                raw=raw,
+                encoding=encoding,
+            )
+    except error.HTTPError as exc:  # pragma: no cover
+        template = "LLM request to '{name}' failed with HTTP status {code}"
+        message = template.format(name=display_name, code=exc.code)
+        raise RuntimeError(message) from exc
+    except error.URLError as exc:
+        message = "Failed to reach LLM endpoint '{name}': {reason}".format(
+            name=display_name,
+            reason=exc.reason,
+        )
+        raise RuntimeError(message) from exc

--- a/sigma/llm_client.py
+++ b/sigma/llm_client.py
@@ -74,7 +74,8 @@ def _prepare_payload(
 
     if not payload:
         raise ValueError(
-            "Payload must include at least one field; provide prompt or extra_payload"
+            "Payload must include at least one field; provide prompt or "
+            "extra_payload"
         )
     try:
         return json.dumps(payload, ensure_ascii=False).encode("utf-8")

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,0 +1,266 @@
+import json
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.append(str(REPO_ROOT))
+
+from sigma.llm_client import LLMResponse, query_llm  # noqa: E402
+
+
+class _RecordingHandler(BaseHTTPRequestHandler):
+    responses: List[Tuple[int, Dict[str, str], bytes]] = []
+    requests: List[Dict[str, Any]] = []
+
+    def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler naming
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length)
+        type(self).requests.append(
+            {
+                "path": self.path,
+                "body": body,
+                "headers": {k.lower(): v for k, v in self.headers.items()},
+            }
+        )
+        if type(self).responses:
+            status, headers, payload = type(self).responses.pop(0)
+        else:
+            status, headers, payload = 500, {"Content-Type": "text/plain"}, b""
+        self.send_response(status)
+        for key, value in headers.items():
+            self.send_header(key, value)
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, *_args: Any, **_kwargs: Any) -> None:
+        return  # pragma: no cover
+
+
+@pytest.fixture
+def llm_test_server() -> Tuple[str, type[_RecordingHandler]]:
+    handler = _RecordingHandler
+    handler.responses = []
+    handler.requests = []
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        host, port = server.server_address
+        yield f"http://{host}:{port}", handler
+    finally:
+        server.shutdown()
+        thread.join()
+
+
+def _write_llms_file(tmp_path: Path, url: str) -> Path:
+    llms_file = tmp_path / "llms.txt"
+    llms_file.write_text(
+        f"## LLM Endpoints\n- [Local]({url})\n",
+        encoding="utf-8",
+    )
+    return llms_file
+
+
+def _latest_request(handler: type[_RecordingHandler]) -> Dict[str, Any]:
+    assert handler.requests, "no request captured"
+    return handler.requests[-1]
+
+
+def test_query_llm_returns_response_field(
+    tmp_path: Path,
+    llm_test_server: Tuple[str, type[_RecordingHandler]],
+) -> None:
+    base_url, handler = llm_test_server
+    handler.responses.append(
+        (
+            200,
+            {"Content-Type": "application/json"},
+            json.dumps({"response": "Hello"}).encode("utf-8"),
+        )
+    )
+    llms_file = _write_llms_file(tmp_path, base_url)
+
+    result = query_llm("Hi there", path=llms_file)
+
+    assert isinstance(result, LLMResponse)
+    assert result.text == "Hello"
+    request_payload = _latest_request(handler)["body"].decode("utf-8")
+    payload = json.loads(request_payload)
+    assert payload == {"prompt": "Hi there"}
+
+
+def test_query_llm_handles_openai_message(
+    tmp_path: Path,
+    llm_test_server: Tuple[str, type[_RecordingHandler]],
+) -> None:
+    base_url, handler = llm_test_server
+    handler.responses.append(
+        (
+            200,
+            {"Content-Type": "application/json"},
+            json.dumps(
+                {
+                    "choices": [
+                        {"message": {"content": "Sigma rocks!"}},
+                        {"message": {"content": "Ignored"}},
+                    ]
+                }
+            ).encode("utf-8"),
+        )
+    )
+    llms_file = _write_llms_file(tmp_path, base_url)
+
+    result = query_llm("Explain Sigma", path=llms_file)
+
+    assert result.text == "Sigma rocks!"
+
+
+def test_query_llm_handles_plain_text(
+    tmp_path: Path,
+    llm_test_server: Tuple[str, type[_RecordingHandler]],
+) -> None:
+    base_url, handler = llm_test_server
+    handler.responses.append(
+        (200, {"Content-Type": "text/plain"}, b"plain text response")
+    )
+    llms_file = _write_llms_file(tmp_path, base_url)
+
+    result = query_llm("Plain please", path=llms_file)
+
+    assert result.text == "plain text response"
+    with pytest.raises(ValueError):
+        result.json()
+
+
+def test_query_llm_extra_payload_included(
+    tmp_path: Path,
+    llm_test_server: Tuple[str, type[_RecordingHandler]],
+) -> None:
+    base_url, handler = llm_test_server
+    handler.responses.append(
+        (
+            200,
+            {"Content-Type": "application/json"},
+            json.dumps({"text": "ack"}).encode("utf-8"),
+        )
+    )
+    llms_file = _write_llms_file(tmp_path, base_url)
+
+    query_llm(
+        "Use extra payload",
+        path=llms_file,
+        extra_payload={"temperature": 0.3, "stream": False},
+    )
+
+    request_payload = _latest_request(handler)["body"].decode("utf-8")
+    payload = json.loads(request_payload)
+    assert payload == {
+        "prompt": "Use extra payload",
+        "temperature": 0.3,
+        "stream": False,
+    }
+
+
+def test_query_llm_rejects_empty_prompt(
+    tmp_path: Path,
+    llm_test_server: Tuple[str, type[_RecordingHandler]],
+) -> None:
+    base_url, _handler = llm_test_server
+    llms_file = _write_llms_file(tmp_path, base_url)
+    with pytest.raises(ValueError):
+        query_llm("   ", path=llms_file)
+
+
+def test_query_llm_rejects_prompt_override(
+    tmp_path: Path,
+    llm_test_server: Tuple[str, type[_RecordingHandler]],
+) -> None:
+    base_url, handler = llm_test_server
+    handler.responses.append(
+        (
+            200,
+            {"Content-Type": "application/json"},
+            json.dumps({"text": "ignored"}).encode("utf-8"),
+        )
+    )
+    llms_file = _write_llms_file(tmp_path, base_url)
+
+    with pytest.raises(ValueError):
+        query_llm(
+            "Hello",
+            path=llms_file,
+            extra_payload={"prompt": "Nope"},
+        )
+
+
+def test_query_llm_requires_http_scheme(tmp_path: Path) -> None:
+    llms_file = tmp_path / "llms.txt"
+    llms_file.write_text(
+        "## LLM Endpoints\n- [Invalid](ws://example.com)\n", encoding="utf-8"
+    )
+    with pytest.raises(RuntimeError):
+        query_llm("hello", path=llms_file)
+
+
+def test_query_llm_errors_on_unparseable_json(
+    tmp_path: Path,
+    llm_test_server: Tuple[str, type[_RecordingHandler]],
+) -> None:
+    base_url, handler = llm_test_server
+    handler.responses.append(
+        (
+            200,
+            {"Content-Type": "application/json"},
+            json.dumps({"unexpected": "format"}).encode("utf-8"),
+        )
+    )
+    llms_file = _write_llms_file(tmp_path, base_url)
+
+    with pytest.raises(
+        RuntimeError,
+        match="without a recognised text field",
+    ):
+        query_llm("testing", path=llms_file)
+
+
+def test_query_llm_handles_choices_text(
+    tmp_path: Path,
+    llm_test_server: Tuple[str, type[_RecordingHandler]],
+) -> None:
+    base_url, handler = llm_test_server
+    handler.responses.append(
+        (
+            200,
+            {"Content-Type": "application/json"},
+            json.dumps({"choices": [{"text": "Choice text"}]}).encode("utf-8"),
+        )
+    )
+    llms_file = _write_llms_file(tmp_path, base_url)
+
+    result = query_llm("Pick a choice", path=llms_file)
+
+    assert result.text == "Choice text"
+
+
+def test_query_llm_http_error(
+    tmp_path: Path,
+    llm_test_server: Tuple[str, type[_RecordingHandler]],
+) -> None:
+    base_url, handler = llm_test_server
+    handler.responses.append(
+        (
+            503,
+            {"Content-Type": "text/plain"},
+            b"Service unavailable",
+        )
+    )
+    llms_file = _write_llms_file(tmp_path, base_url)
+
+    with pytest.raises(RuntimeError, match="HTTP status 503"):
+        query_llm("Are you there?", path=llms_file)

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -225,9 +225,10 @@ def test_query_llm_supports_messages_only_payload(
         },
     )
 
-    request_payload = json.loads(_latest_request(handler)["body"].decode("utf-8"))
-    assert "prompt" not in request_payload
-    assert request_payload["messages"][0]["content"] == "Hi"
+    request_body = _latest_request(handler)["body"].decode("utf-8")
+    payload = json.loads(request_body)
+    assert "prompt" not in payload
+    assert payload["messages"][0]["content"] == "Hi"
 
 
 def test_query_llm_rejects_empty_payload(


### PR DESCRIPTION
## Summary
- add a sigma.query_llm helper that posts prompts to the resolved LLM
- expose the helper in the package and document how to use it
- cover the new helper with a local HTTP test harness

## Testing
- pre-commit run --all-files
- make test

------
https://chatgpt.com/codex/tasks/task_e_68e3134ada38832f92e652c3181b231f