### PR TITLE
✅ : – preserve llms URL whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ so `## llm endpoints` also works. Closing `#` characters are ignored,
 so `## LLM Endpoints ##` is treated the same way.
 Bullet links may start with `-`, `*`, or `+`; spacing after the bullet is optional, so
 `-[Example](https://example.com)` and `-   [Example](https://example.com)` both work.
-URLs may include balanced parentheses in the link target and are preserved as written.
+URLs may include balanced parentheses in the link target and are preserved as written,
+including any leading or trailing whitespace inside the parentheses.
 Single-`#` comment lines are allowed before the list begins, but once endpoints appear a
 new single-`#` heading ends the section the same way any `##` heading does.
 

--- a/docs/llms-guide.md
+++ b/docs/llms-guide.md
@@ -5,7 +5,8 @@ The `llms.txt` file uses Markdown bullet lists under the `## LLM Endpoints`
 heading; entries can start with `-`, `*`, or `+`. Trailing `#` characters after
 the heading text are ignored, so `## LLM Endpoints ##` is also recognised.
 URLs may include balanced parentheses inside the link target; the parser keeps
-them intact when returning entries.
+them intact when returning entries, including any leading or trailing whitespace
+inside the parentheses.
 Comments that start with a single `#` may appear before the list, but once an
 endpoint has been parsed another single-`#` heading terminates the section just
 like a `##` heading.

--- a/llms.py
+++ b/llms.py
@@ -87,9 +87,11 @@ def get_llm_endpoints(path: str | Path | None = None) -> List[Tuple[str, str]]:
             continue
         name, url = link
         normalized_url = url.strip()
+        if not normalized_url:
+            continue
         lowered = normalized_url.casefold()
-        if lowered.startswith("http://") or lowered.startswith("https://"):
-            endpoints.append((name, normalized_url))
+        if lowered.startswith(("http://", "https://")):
+            endpoints.append((name, url))
             section_has_entry = True
     return endpoints
 

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -128,6 +128,16 @@ def test_get_llm_endpoints_allows_parentheses_in_url(tmp_path):
     assert endpoints == [("Example", expected_url)]
 
 
+def test_get_llm_endpoints_preserves_url_whitespace(tmp_path):
+    llms_file = tmp_path / "custom.txt"
+    llms_file.write_text(
+        "## LLM Endpoints\n- [Example]( https://example.com/path )\n",
+        encoding="utf-8",
+    )
+    endpoints = llms.get_llm_endpoints(llms_file)
+    assert endpoints == [("Example", " https://example.com/path ")]
+
+
 def test_get_llm_endpoints_expands_env_vars(tmp_path, monkeypatch):
     llms_file = tmp_path / "custom.txt"
     llms_file.write_text(


### PR DESCRIPTION
what: keep llms endpoints' URLs exactly as written and add regression
test; refresh docs about whitespace handling.
why: docs promise to preserve URLs verbatim but the parser trimmed
surrounding spaces.
how to test: pre-commit run --all-files && pytest -q.

Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68e3134ada38832f92e652c3181b231f