### PR TITLE
✨ : – Trim whitespace in LLM endpoint selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ name, url = resolve_llm_endpoint("OpenRouter")  # case-insensitive lookup
 
 Set the `SIGMA_DEFAULT_LLM` environment variable to override the default without
 changing code; surrounding whitespace is ignored, and the resolver raises an error if the
-variable is empty or references an unknown entry.
+variable is empty or references an unknown entry. Direct lookups via the `name` argument
+receive the same whitespace trimming so `resolve_llm_endpoint("  OpenRouter  ")` succeeds.
 
 You can list the configured endpoints with:
 

--- a/docs/llms-guide.md
+++ b/docs/llms-guide.md
@@ -69,7 +69,8 @@ name, url = resolve_llm_endpoint("OpenRouter")  # case-insensitive lookup
 Set the `SIGMA_DEFAULT_LLM` environment variable to change the default without
 modifying code. Leading and trailing whitespace is ignored, and the resolver
 raises an error if the variable is empty, references an unknown endpoint, or if
-`llms.txt` does not list any entries.
+`llms.txt` does not list any entries. Explicit `name` lookups receive the same
+trimming, so `resolve_llm_endpoint("  OpenRouter  ")` resolves successfully.
 
 ## Issuing a Request
 

--- a/llms.py
+++ b/llms.py
@@ -115,16 +115,24 @@ def resolve_llm_endpoint(
         return ", ".join(display for display, _ in endpoints)
 
     if name is not None:
-        candidate = lookup.get(name.casefold())
+        normalized_name = name.strip()
+        if not normalized_name:
+            raise ValueError("Endpoint name must be a non-empty string")
+
+        candidate = lookup.get(normalized_name.casefold())
         if candidate is not None:
             return candidate
         available = _format_available()
-        message = " ".join(
-            [
-                f"Unknown LLM endpoint '{name}'.",
-                f"Available endpoints: {available}",
-            ]
-        )
+        if normalized_name == name:
+            detail = f"Unknown LLM endpoint '{name}'."
+        else:
+            detail = "".join(
+                [
+                    "Unknown LLM endpoint ",
+                    f"{name!r} (normalized to {normalized_name!r}).",
+                ]
+            )
+        message = " ".join([detail, f"Available endpoints: {available}"])
         raise ValueError(message)
 
     env_preference_raw = os.getenv("SIGMA_DEFAULT_LLM")

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -195,6 +195,31 @@ def test_resolve_llm_endpoint_respects_explicit_name(tmp_path):
     assert url == "https://beta.example.com"
 
 
+def test_resolve_llm_endpoint_strips_name_whitespace(tmp_path):
+    llms_file = tmp_path / "custom.txt"
+    llms_file.write_text(
+        (
+            "## LLM Endpoints\n"
+            "- [Alpha](https://alpha.example.com)\n"
+            "- [Beta](https://beta.example.com)\n"
+        ),
+        encoding="utf-8",
+    )
+    name, url = llms.resolve_llm_endpoint("  Beta  ", path=llms_file)
+    assert name == "Beta"
+    assert url == "https://beta.example.com"
+
+
+def test_resolve_llm_endpoint_rejects_blank_name(tmp_path):
+    llms_file = tmp_path / "custom.txt"
+    llms_file.write_text(
+        "## LLM Endpoints\n- [Alpha](https://alpha.example.com)\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="non-empty"):
+        llms.resolve_llm_endpoint("   ", path=llms_file)
+
+
 def test_resolve_llm_endpoint_respects_env_variable(tmp_path, monkeypatch):
     llms_file = tmp_path / "custom.txt"
     llms_file.write_text(
@@ -355,6 +380,33 @@ def test_llms_cli_resolve_with_name(tmp_path):
             "--resolve",
             "--name",
             "beta",
+            str(llms_file),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert result.stdout.strip() == "Beta: https://beta.example.com"
+
+
+def test_llms_cli_resolve_name_strips_whitespace(tmp_path):
+    llms_file = tmp_path / "custom.txt"
+    llms_file.write_text(
+        (
+            "## LLM Endpoints\n"
+            "- [Alpha](https://alpha.example.com)\n"
+            "- [Beta](https://beta.example.com)\n"
+        ),
+        encoding="utf-8",
+    )
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "llms",
+            "--resolve",
+            "--name",
+            "  beta  ",
             str(llms_file),
         ],
         check=True,


### PR DESCRIPTION
what: Trim resolve_llm_endpoint name inputs and add coverage/docs.
why: Match documented whitespace tolerance for env defaults and avoid surprises.
how to test: python -m pre_commit run --all-files && make test.

------
https://chatgpt.com/codex/tasks/task_e_68e357b3205c832f99132f5c4c8348a1