### PR TITLE
Raise errors for malformed JSON LLM replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,9 +205,9 @@ print(result.status)  # HTTP status code
 print(result.json())  # Full JSON payload when available
 ```
 
-The helper raises `RuntimeError` if the endpoint does not speak HTTP(S) or if a
-JSON reply lacks an obvious text field, making integration failures easier to
-spot.
+The helper raises `RuntimeError` if the endpoint does not speak HTTP(S), if a
+JSON reply is malformed or empty, or if it lacks an obvious text field, making
+integration failures easier to spot.
 
 ## Roadmap
 

--- a/docs/llms-guide.md
+++ b/docs/llms-guide.md
@@ -78,4 +78,5 @@ payload to the selected HTTP(S) endpoint. It accepts an optional
 `extra_payload` mapping for provider-specific parameters and extracts a reply
 from common response shapes (`response`, `text`, or the first
 `choices[].message.content`). Plain-text responses are returned unchanged, and a
-`RuntimeError` is raised if a JSON response cannot be interpreted.
+`RuntimeError` is raised if a JSON response is malformed, empty, or otherwise
+cannot be interpreted.

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -272,6 +272,42 @@ def test_query_llm_errors_on_unparseable_json(
         query_llm("testing", path=llms_file)
 
 
+def test_query_llm_errors_on_invalid_json(
+    tmp_path: Path,
+    llm_test_server: Tuple[str, type[_RecordingHandler]],
+) -> None:
+    base_url, handler = llm_test_server
+    handler.responses.append(
+        (
+            200,
+            {"Content-Type": "application/json"},
+            b"{invalid",
+        )
+    )
+    llms_file = _write_llms_file(tmp_path, base_url)
+
+    with pytest.raises(RuntimeError, match="invalid JSON"):
+        query_llm("Hello?", path=llms_file)
+
+
+def test_query_llm_errors_on_empty_json(
+    tmp_path: Path,
+    llm_test_server: Tuple[str, type[_RecordingHandler]],
+) -> None:
+    base_url, handler = llm_test_server
+    handler.responses.append(
+        (
+            200,
+            {"Content-Type": "application/json"},
+            b"",
+        )
+    )
+    llms_file = _write_llms_file(tmp_path, base_url)
+
+    with pytest.raises(RuntimeError, match="empty JSON response"):
+        query_llm("Hello?", path=llms_file)
+
+
 def test_query_llm_handles_choices_text(
     tmp_path: Path,
     llm_test_server: Tuple[str, type[_RecordingHandler]],


### PR DESCRIPTION
## Summary
- raise RuntimeError when LLM endpoints return malformed or empty JSON payloads
- add tests covering invalid and empty JSON responses from the test server
- document the stricter JSON error handling in the README and LLM guide

## Testing
- python -m pre_commit run --all-files
- make test

------
https://chatgpt.com/codex/tasks/task_e_68e357b3205c832f99132f5c4c8348a1