### PR TITLE
✨ : support OpenAI list-based message content

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,8 +182,9 @@ Use `sigma.query_llm` to send a prompt to the currently configured LLM endpoint.
 The helper resolves the endpoint via `llms.resolve_llm_endpoint`, sends a JSON
 payload containing the prompt, and extracts a sensible reply from common JSON
 shapes (`{"response": ...}`, `{"text": ...}`, or OpenAI-style
-`{"choices": [{"message": {"content": ...}}]}`). Plain-text responses are
-returned as-is.
+`{"choices": [{"message": {"content": ...}}]}`). When `message.content`
+contains a list of text segments (as returned by newer OpenAI APIs) the helper
+concatenates the pieces automatically. Plain-text responses are returned as-is.
 
 ```python
 from sigma import query_llm

--- a/docs/llms-guide.md
+++ b/docs/llms-guide.md
@@ -77,5 +77,7 @@ The `sigma.query_llm` helper wraps `resolve_llm_endpoint` and submits a JSON
 payload to the selected HTTP(S) endpoint. It accepts an optional
 `extra_payload` mapping for provider-specific parameters and extracts a reply
 from common response shapes (`response`, `text`, or the first
-`choices[].message.content`). Plain-text responses are returned unchanged, and a
+`choices[].message.content`). If the message content is provided as a list of
+text fragments (as in the latest OpenAI APIs) the helper concatenates the
+segments for you. Plain-text responses are returned unchanged, and a
 `RuntimeError` is raised if a JSON response cannot be interpreted.

--- a/sigma/llm_client.py
+++ b/sigma/llm_client.py
@@ -45,6 +45,66 @@ _SUPPORTED_SCHEMES = {"http", "https"}
 _JSON_CONTENT_TYPES = {"application/json", "text/json"}
 
 
+def _join_text_parts(parts: Any) -> str | None:
+    """Return concatenated text extracted from iterable ``parts``."""
+
+    if isinstance(parts, str):
+        return parts
+    if isinstance(parts, Mapping):
+        return _extract_message_content(parts)
+    if not isinstance(parts, list):
+        nested = _extract_text(parts)
+        return nested if isinstance(nested, str) else None
+
+    fragments: list[str] = []
+    for part in parts:
+        if isinstance(part, str):
+            fragments.append(part)
+            continue
+        if isinstance(part, Mapping):
+            text_value = part.get("text")
+            if isinstance(text_value, str):
+                fragments.append(text_value)
+                continue
+            nested = part.get("content")
+            nested_text = _join_text_parts(nested)
+            if isinstance(nested_text, str):
+                fragments.append(nested_text)
+                continue
+        elif isinstance(part, list):
+            nested_text = _join_text_parts(part)
+            if isinstance(nested_text, str):
+                fragments.append(nested_text)
+                continue
+        else:
+            nested_text = _extract_text(part)
+            if isinstance(nested_text, str):
+                fragments.append(nested_text)
+                continue
+    if fragments:
+        return "".join(fragments)
+    return None
+
+
+def _extract_message_content(content: Any) -> str | None:
+    """Return text extracted from OpenAI-style ``message.content`` values."""
+
+    if isinstance(content, str):
+        return content
+    if isinstance(content, Mapping):
+        direct_text = content.get("text")
+        if isinstance(direct_text, str):
+            return direct_text
+        nested_content = content.get("content")
+        if nested_content is not None:
+            return _extract_message_content(nested_content)
+        return None
+    if isinstance(content, list):
+        return _join_text_parts(content)
+    nested = _extract_text(content)
+    return nested if isinstance(nested, str) else None
+
+
 def _ensure_prompt(prompt: str) -> str:
     if not isinstance(prompt, str):
         raise TypeError("prompt must be a string")
@@ -92,6 +152,14 @@ def _extract_text(data: Any) -> str | None:
             value = data.get(key)
             if isinstance(value, str):
                 return value
+        direct_content = _extract_message_content(data.get("content"))
+        if isinstance(direct_content, str):
+            return direct_content
+        message_value = data.get("message")
+        if message_value is not None:
+            message_text = _extract_text(message_value)
+            if isinstance(message_text, str):
+                return message_text
         choices = data.get("choices")
         if isinstance(choices, list):
             for choice in choices:
@@ -101,16 +169,19 @@ def _extract_text(data: Any) -> str | None:
                 if isinstance(text_value, str):
                     return text_value
                 message = choice.get("message")
-                if isinstance(message, Mapping):
-                    content = message.get("content")
-                    if isinstance(content, str):
-                        return content
+                if message is not None:
+                    content_text = _extract_text(message)
+                    if isinstance(content_text, str):
+                        return content_text
         data_field = data.get("data")
         if data_field is not None:
             nested = _extract_text(data_field)
             if isinstance(nested, str):
                 return nested
     if isinstance(data, list):
+        combined = _join_text_parts(data)
+        if isinstance(combined, str):
+            return combined
         for item in data:
             text_value = _extract_text(item)
             if isinstance(text_value, str):

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -121,6 +121,38 @@ def test_query_llm_handles_openai_message(
     assert result.text == "Sigma rocks!"
 
 
+def test_query_llm_handles_openai_content_list(
+    tmp_path: Path,
+    llm_test_server: Tuple[str, type[_RecordingHandler]],
+) -> None:
+    base_url, handler = llm_test_server
+    handler.responses.append(
+        (
+            200,
+            {"Content-Type": "application/json"},
+            json.dumps(
+                {
+                    "choices": [
+                        {
+                            "message": {
+                                "content": [
+                                    {"type": "text", "text": "Hello"},
+                                    {"type": "text", "text": " world"},
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ).encode("utf-8"),
+        )
+    )
+    llms_file = _write_llms_file(tmp_path, base_url)
+
+    result = query_llm("Segmented", path=llms_file)
+
+    assert result.text == "Hello world"
+
+
 def test_query_llm_handles_plain_text(
     tmp_path: Path,
     llm_test_server: Tuple[str, type[_RecordingHandler]],


### PR DESCRIPTION
what: Add message.content list flattening to query_llm plus docs/tests.
why: OpenAI APIs return segmented content; README promises compatibility.
how to test: pre-commit run --all-files && make test

------
https://chatgpt.com/codex/tasks/task_e_68e357b3205c832f99132f5c4c8348a1