### PR TITLE
✨ : – Preserve prompt argument when extra_payload sets prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,9 @@ print(result.text)
 ```
 
 Supply `extra_payload` to add provider-specific options without clobbering the
-prompt, and pass `name=` to target a specific endpoint:
+prompt; when the `prompt` argument is provided any `prompt` key in
+`extra_payload` is ignored, so set `prompt=None` if you need to manage the
+field yourself. Pass `name=` to target a specific endpoint:
 
 ```python
 result = query_llm(

--- a/docs/llms-guide.md
+++ b/docs/llms-guide.md
@@ -77,7 +77,10 @@ trimming, so `resolve_llm_endpoint("  OpenRouter  ")` resolves successfully.
 
 The `sigma.query_llm` helper wraps `resolve_llm_endpoint` and submits a JSON
 payload to the selected HTTP(S) endpoint. It accepts an optional
-`extra_payload` mapping for provider-specific parameters and extracts a reply
+`extra_payload` mapping for provider-specific parameters and ignores any
+`prompt` field from that mapping when the function's `prompt` argument is
+present, ensuring helper callers retain control of the final prompt value. Pass
+`prompt=None` to supply the field yourself when needed. The helper extracts a reply
 from common response shapes (`response`, `text`, or the first
 `choices[].message.content`). If the message content is provided as a list of
 text fragments (as in the latest OpenAI APIs) the helper concatenates the

--- a/sigma/llm_client.py
+++ b/sigma/llm_client.py
@@ -126,10 +126,9 @@ def _prepare_payload(
         payload = {}
 
     if prompt is not None:
-        prompt_value = _ensure_prompt(prompt)
-        payload.setdefault("prompt", prompt_value)
-
-    if "prompt" in payload:
+        payload.pop("prompt", None)
+        payload["prompt"] = _ensure_prompt(prompt)
+    elif "prompt" in payload:
         payload["prompt"] = _ensure_prompt(payload["prompt"])
 
     if not payload:


### PR DESCRIPTION
what: ensure query_llm ignores extra_payload['prompt'] when prompt is set.
why: README promised provider-specific options would not clobber prompts.
how to test: pre-commit run --all-files; make test


------
https://chatgpt.com/codex/tasks/task_e_68e3f9eb0684832fafd0f5544137a8fe