### PR TITLE
✨ : Support streaming delta payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,11 +182,13 @@ print(clamp(Decimal("1.5"), Decimal("0"), Decimal("2")))  # Decimal('1.5')
 
 Use `sigma.query_llm` to send a prompt to the currently configured LLM endpoint.
 The helper resolves the endpoint via `llms.resolve_llm_endpoint`, sends a JSON
-payload containing the prompt, and extracts a sensible reply from common JSON
-shapes (`{"response": ...}`, `{"text": ...}`, or OpenAI-style
-`{"choices": [{"message": {"content": ...}}]}`). When `message.content`
-contains a list of text segments (as returned by newer OpenAI APIs) the helper
-concatenates the pieces automatically. Plain-text responses are returned as-is.
+ payload containing the prompt, and extracts a sensible reply from common JSON
+ shapes (`{"response": ...}`, `{"text": ...}`, OpenAI-style chat payloads
+ `{"choices": [{"message": {"content": ...}}]}`, or streaming-style
+ deltas `{"choices": [{"delta": {"content": ...}}]}`). When `message.content`
+ or `delta.content` contains a list of text segments (as returned by newer
+ OpenAI APIs) the helper concatenates the pieces automatically. Plain-text
+ responses are returned as-is.
 
 ```python
 from sigma import query_llm

--- a/docs/llms-guide.md
+++ b/docs/llms-guide.md
@@ -78,8 +78,9 @@ trimming, so `resolve_llm_endpoint("  OpenRouter  ")` resolves successfully.
 The `sigma.query_llm` helper wraps `resolve_llm_endpoint` and submits a JSON
 payload to the selected HTTP(S) endpoint. It accepts an optional
 `extra_payload` mapping for provider-specific parameters and extracts a reply
-from common response shapes (`response`, `text`, or the first
-`choices[].message.content`). If the message content is provided as a list of
-text fragments (as in the latest OpenAI APIs) the helper concatenates the
-segments for you. Plain-text responses are returned unchanged, and a
-`RuntimeError` is raised if a JSON response cannot be interpreted.
+from common response shapes (`response`, `text`, the first
+`choices[].message.content`, or streaming deltas in `choices[].delta.content`).
+If the message or delta content is provided as a list of text fragments (as in
+the latest OpenAI APIs) the helper concatenates the segments for you.
+Plain-text responses are returned unchanged, and a `RuntimeError` is raised if a
+JSON response cannot be interpreted.

--- a/sigma/llm_client.py
+++ b/sigma/llm_client.py
@@ -173,6 +173,11 @@ def _extract_text(data: Any) -> str | None:
                     content_text = _extract_text(message)
                     if isinstance(content_text, str):
                         return content_text
+                delta = choice.get("delta")
+                if delta is not None:
+                    delta_text = _extract_text(delta)
+                    if isinstance(delta_text, str):
+                        return delta_text
         data_field = data.get("data")
         if data_field is not None:
             nested = _extract_text(data_field)

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -153,6 +153,38 @@ def test_query_llm_handles_openai_content_list(
     assert result.text == "Hello world"
 
 
+def test_query_llm_handles_openai_delta_segments(
+    tmp_path: Path,
+    llm_test_server: Tuple[str, type[_RecordingHandler]],
+) -> None:
+    base_url, handler = llm_test_server
+    handler.responses.append(
+        (
+            200,
+            {"Content-Type": "application/json"},
+            json.dumps(
+                {
+                    "choices": [
+                        {
+                            "delta": {
+                                "content": [
+                                    {"type": "text", "text": "Hello"},
+                                    {"type": "text", "text": " world"},
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ).encode("utf-8"),
+        )
+    )
+    llms_file = _write_llms_file(tmp_path, base_url)
+
+    result = query_llm("Streaming", path=llms_file)
+
+    assert result.text == "Hello world"
+
+
 def test_query_llm_handles_plain_text(
     tmp_path: Path,
     llm_test_server: Tuple[str, type[_RecordingHandler]],


### PR DESCRIPTION
what: add delta parsing to query_llm and exercise it via tests/docs
why: keep helper aligned with the documented common LLM response shapes
how to test: python -m pre_commit run --all-files; make test

------
https://chatgpt.com/codex/tasks/task_e_68e3f9eb0684832fafd0f5544137a8fe