### PR TITLE
✨ : add llm auth header support

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,13 @@ print(result.status)  # HTTP status code
 print(result.json())  # Full JSON payload when available
 ```
 
+Secure endpoints such as OpenRouter or the OpenAI API often require an
+`Authorization` header. Set `SIGMA_LLM_AUTH_TOKEN` to inject a bearer token into
+every request. The value is trimmed before use; if the variable is present but
+empty a `RuntimeError` is raised to surface misconfiguration quickly. Provide an
+optional `SIGMA_LLM_AUTH_SCHEME` to override the default `Bearer` prefix (set it
+to an empty string to send the raw token).
+
 The helper raises `RuntimeError` if the endpoint does not speak HTTP(S), if a
 JSON reply is malformed or empty, or if it lacks an obvious text field, making
 integration failures easier to spot.

--- a/docs/llms-guide.md
+++ b/docs/llms-guide.md
@@ -83,3 +83,9 @@ from common response shapes (`response`, `text`, or the first
 text fragments (as in the latest OpenAI APIs) the helper concatenates the
 segments for you. Plain-text responses are returned unchanged, and a
 `RuntimeError` is raised if a JSON response cannot be interpreted.
+
+Most hosted providers also expect an `Authorization` header. Configure
+`SIGMA_LLM_AUTH_TOKEN` with your API key to add one automatically. The helper
+normalises the token by stripping whitespace and raises a `RuntimeError` if the
+variable is set but empty. Use `SIGMA_LLM_AUTH_SCHEME` to customise the prefix
+(`Bearer` by default, set it to an empty string to send the raw token).

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -199,6 +199,65 @@ def test_query_llm_extra_payload_included(
     }
 
 
+def test_query_llm_includes_authorisation_header(
+    tmp_path: Path,
+    llm_test_server: Tuple[str, type[_RecordingHandler]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    base_url, handler = llm_test_server
+    handler.responses.append(
+        (
+            200,
+            {"Content-Type": "application/json"},
+            json.dumps({"text": "ok"}).encode("utf-8"),
+        )
+    )
+    llms_file = _write_llms_file(tmp_path, base_url)
+
+    monkeypatch.setenv("SIGMA_LLM_AUTH_TOKEN", "secret-token")
+
+    query_llm("Auth please", path=llms_file)
+
+    headers = _latest_request(handler)["headers"]
+    assert headers.get("authorization") == "Bearer secret-token"
+
+
+def test_query_llm_customises_authorisation_scheme(
+    tmp_path: Path,
+    llm_test_server: Tuple[str, type[_RecordingHandler]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    base_url, handler = llm_test_server
+    handler.responses.append(
+        (
+            200,
+            {"Content-Type": "application/json"},
+            json.dumps({"text": "ack"}).encode("utf-8"),
+        )
+    )
+    llms_file = _write_llms_file(tmp_path, base_url)
+
+    monkeypatch.setenv("SIGMA_LLM_AUTH_TOKEN", "abc123")
+    monkeypatch.setenv("SIGMA_LLM_AUTH_SCHEME", "ApiKey")
+
+    query_llm("Custom scheme", path=llms_file)
+    headers = _latest_request(handler)["headers"]
+    assert headers.get("authorization") == "ApiKey abc123"
+
+    handler.responses.append(
+        (
+            200,
+            {"Content-Type": "application/json"},
+            json.dumps({"text": "ack"}).encode("utf-8"),
+        )
+    )
+    monkeypatch.setenv("SIGMA_LLM_AUTH_SCHEME", "   ")
+
+    query_llm("No scheme", path=llms_file)
+    headers = _latest_request(handler)["headers"]
+    assert headers.get("authorization") == "abc123"
+
+
 def test_query_llm_rejects_empty_prompt(
     tmp_path: Path,
     llm_test_server: Tuple[str, type[_RecordingHandler]],
@@ -272,6 +331,20 @@ def test_query_llm_rejects_empty_payload(
 
     with pytest.raises(ValueError):
         query_llm(None, path=llms_file)
+
+
+def test_query_llm_empty_authorisation_token_raises(
+    tmp_path: Path,
+    llm_test_server: Tuple[str, type[_RecordingHandler]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    base_url, _handler = llm_test_server
+    llms_file = _write_llms_file(tmp_path, base_url)
+
+    monkeypatch.setenv("SIGMA_LLM_AUTH_TOKEN", "   ")
+
+    with pytest.raises(RuntimeError, match="SIGMA_LLM_AUTH_TOKEN"):
+        query_llm("hello", path=llms_file)
 
 
 def test_query_llm_requires_http_scheme(tmp_path: Path) -> None:


### PR DESCRIPTION
What: add env-driven Authorization header support to query_llm.
Why: enables documented OpenRouter/OpenAI endpoints that need tokens.
How to test: pre-commit run --all-files && make test.


------
https://chatgpt.com/codex/tasks/task_e_68e3f9eb0684832fafd0f5544137a8fe