### PR TITLE
✅ : accept colon+hash llm headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ Use the `llms.py` helper to manage language model endpoints.
 Configure LLM endpoints in [`llms.txt`](llms.txt), which the [`llms.py`](llms.py) helper parses.
 The parser matches the `## LLM Endpoints` heading case-insensitively,
 so `## llm endpoints` also works. Closing `#` characters and an optional
-trailing colon are ignored, so `## LLM Endpoints ##` and
-`## LLM Endpoints:` are treated the same way.
+trailing colon are ignored, so `## LLM Endpoints ##`, `## LLM Endpoints:`, and
+`## LLM Endpoints ##:` are treated the same way.
 Bullet links may start with `-`, `*`, or `+`; spacing after the bullet is optional, so
 `-[Example](https://example.com)` and `-   [Example](https://example.com)` both work.
 URLs may include balanced parentheses in the link target and are preserved as written,

--- a/docs/llms-guide.md
+++ b/docs/llms-guide.md
@@ -3,8 +3,8 @@
 `llms.py` parses `llms.txt` to discover available language model endpoints.
 The `llms.txt` file uses Markdown bullet lists under the `## LLM Endpoints`
 heading; entries can start with `-`, `*`, or `+`. Trailing `#` characters after
-the heading text and an optional colon are ignored, so `## LLM Endpoints ##`
-and `## LLM Endpoints:` are both recognised.
+the heading text and an optional colon are ignored, so `## LLM Endpoints ##`,
+`## LLM Endpoints:`, and `## LLM Endpoints ##:` are all recognised.
 URLs may include balanced parentheses inside the link target; the parser keeps
 them intact when returning entries, including any leading or trailing whitespace
 inside the parentheses.

--- a/llms.py
+++ b/llms.py
@@ -74,7 +74,7 @@ def get_llm_endpoints(path: str | Path | None = None) -> List[Tuple[str, str]]:
             level = len(heading.group(1))
             if level <= 2:
                 title = heading.group(2).strip()
-                title = title.rstrip(":").strip()
+                title = title.rstrip("#:").strip()
                 in_section = title.casefold() == "llm endpoints"
                 section_has_entry = False
             continue

--- a/tests/test_llms.py
+++ b/tests/test_llms.py
@@ -94,6 +94,16 @@ def test_get_llm_endpoints_heading_allows_trailing_colon(tmp_path):
     assert endpoints == {"Example": "https://example.com"}
 
 
+def test_get_llm_endpoints_heading_allows_colon_and_hashes(tmp_path):
+    llms_file = tmp_path / "custom.txt"
+    llms_file.write_text(
+        "## LLM Endpoints ##:\n- [Example](https://example.com)",
+        encoding="utf-8",
+    )
+    endpoints = dict(llms.get_llm_endpoints(str(llms_file)))
+    assert endpoints == {"Example": "https://example.com"}
+
+
 def test_get_llm_endpoints_allows_indented_bullets(tmp_path):
     llms_file = tmp_path / "custom.txt"
     llms_file.write_text(


### PR DESCRIPTION
what: allow llms heading parser to ignore combined # and : suffixes
why: docs promise closing hashes and optional colons are ignored
how to test: pre-commit run --all-files && make test

------
https://chatgpt.com/codex/tasks/task_e_68e4c12c2e0c832fa8f915da9c2df873