### PR TITLE
Handle OpenAI Responses API text.value segments

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,8 @@ The helper resolves the endpoint via `llms.resolve_llm_endpoint`, sends a JSON
  `{"choices": [{"message": {"content": ...}}]}`, or streaming-style
  deltas `{"choices": [{"delta": {"content": ...}}]}`). When `message.content`
  or `delta.content` contains a list of text segments (as returned by newer
- OpenAI APIs) the helper concatenates the pieces automatically. Plain-text
+ OpenAI APIs) the helper concatenates the pieces automatically, including
+ segments whose `text` field is an object with a `value` string. Plain-text
  responses are returned as-is.
 
 ```python

--- a/docs/llms-guide.md
+++ b/docs/llms-guide.md
@@ -84,9 +84,10 @@ present, ensuring helper callers retain control of the final prompt value. Pass
 from common response shapes (`response`, `text`, the first
 `choices[].message.content`, or streaming deltas in `choices[].delta.content`).
 If the message or delta content is provided as a list of text fragments (as in
-the latest OpenAI APIs) the helper concatenates the segments for you.
-Plain-text responses are returned unchanged, and a `RuntimeError` is raised if a
-JSON response cannot be interpreted.
+the latest OpenAI APIs) the helper concatenates the segments for you, including
+cases where each fragment stores its text inside an object with a `value`
+string. Plain-text responses are returned unchanged, and a `RuntimeError` is
+raised if a JSON response cannot be interpreted.
 
 Most hosted providers also expect an `Authorization` header. Configure
 `SIGMA_LLM_AUTH_TOKEN` with your API key to add one automatically. The helper

--- a/sigma/llm_client.py
+++ b/sigma/llm_client.py
@@ -49,64 +49,45 @@ _AUTH_TOKEN_ENV = "SIGMA_LLM_AUTH_TOKEN"
 _AUTH_SCHEME_ENV = "SIGMA_LLM_AUTH_SCHEME"
 
 
+def _extract_text_value(value: Any) -> str | None:
+    """Return text extracted from *value* when present."""
+
+    if isinstance(value, str):
+        return value
+    if isinstance(value, Mapping):
+        for key in ("response", "text", "value", "content"):
+            if key in value:
+                candidate = _extract_text_value(value[key])
+                if isinstance(candidate, str):
+                    return candidate
+        for key in ("message", "delta", "data"):
+            nested = value.get(key)
+            if nested is not None:
+                candidate = _extract_text_value(nested)
+                if isinstance(candidate, str):
+                    return candidate
+        return None
+    if isinstance(value, list):
+        fragments: list[str] = []
+        for item in value:
+            fragment = _extract_text_value(item)
+            if isinstance(fragment, str):
+                fragments.append(fragment)
+        if fragments:
+            return "".join(fragments)
+    return None
+
+
 def _join_text_parts(parts: Any) -> str | None:
     """Return concatenated text extracted from iterable ``parts``."""
 
-    if isinstance(parts, str):
-        return parts
-    if isinstance(parts, Mapping):
-        return _extract_message_content(parts)
-    if not isinstance(parts, list):
-        nested = _extract_text(parts)
-        return nested if isinstance(nested, str) else None
-
-    fragments: list[str] = []
-    for part in parts:
-        if isinstance(part, str):
-            fragments.append(part)
-            continue
-        if isinstance(part, Mapping):
-            text_value = part.get("text")
-            if isinstance(text_value, str):
-                fragments.append(text_value)
-                continue
-            nested = part.get("content")
-            nested_text = _join_text_parts(nested)
-            if isinstance(nested_text, str):
-                fragments.append(nested_text)
-                continue
-        elif isinstance(part, list):
-            nested_text = _join_text_parts(part)
-            if isinstance(nested_text, str):
-                fragments.append(nested_text)
-                continue
-        else:
-            nested_text = _extract_text(part)
-            if isinstance(nested_text, str):
-                fragments.append(nested_text)
-                continue
-    if fragments:
-        return "".join(fragments)
-    return None
+    return _extract_text_value(parts)
 
 
 def _extract_message_content(content: Any) -> str | None:
     """Return text extracted from OpenAI-style ``message.content`` values."""
 
-    if isinstance(content, str):
-        return content
-    if isinstance(content, Mapping):
-        direct_text = content.get("text")
-        if isinstance(direct_text, str):
-            return direct_text
-        nested_content = content.get("content")
-        if nested_content is not None:
-            return _extract_message_content(nested_content)
-        return None
-    if isinstance(content, list):
-        return _join_text_parts(content)
-    nested = _extract_text(content)
-    return nested if isinstance(nested, str) else None
+    return _extract_text_value(content)
 
 
 def _ensure_prompt(prompt: str) -> str:
@@ -171,52 +152,23 @@ def _build_authorisation_header() -> Mapping[str, str]:
 
 
 def _extract_text(data: Any) -> str | None:
-    if isinstance(data, str):
-        return data
+    direct = _extract_text_value(data)
+    if isinstance(direct, str):
+        return direct
     if isinstance(data, Mapping):
-        for key in ("response", "text"):
-            value = data.get(key)
-            if isinstance(value, str):
-                return value
-        direct_content = _extract_message_content(data.get("content"))
-        if isinstance(direct_content, str):
-            return direct_content
-        message_value = data.get("message")
-        if message_value is not None:
-            message_text = _extract_text(message_value)
-            if isinstance(message_text, str):
-                return message_text
         choices = data.get("choices")
         if isinstance(choices, list):
             for choice in choices:
-                if not isinstance(choice, Mapping):
-                    continue
-                text_value = choice.get("text")
-                if isinstance(text_value, str):
-                    return text_value
-                message = choice.get("message")
-                if message is not None:
-                    content_text = _extract_text(message)
-                    if isinstance(content_text, str):
-                        return content_text
-                delta = choice.get("delta")
-                if delta is not None:
-                    delta_text = _extract_text(delta)
-                    if isinstance(delta_text, str):
-                        return delta_text
+                choice_text = _extract_text_value(choice)
+                if isinstance(choice_text, str):
+                    return choice_text
         data_field = data.get("data")
         if data_field is not None:
-            nested = _extract_text(data_field)
+            nested = _extract_text_value(data_field)
             if isinstance(nested, str):
                 return nested
     if isinstance(data, list):
-        combined = _join_text_parts(data)
-        if isinstance(combined, str):
-            return combined
-        for item in data:
-            text_value = _extract_text(item)
-            if isinstance(text_value, str):
-                return text_value
+        return _extract_text_value(data)
     return None
 
 

--- a/sigma/llm_client.py
+++ b/sigma/llm_client.py
@@ -164,7 +164,7 @@ def _extract_text(data: Any) -> str | None:
                     return choice_text
         data_field = data.get("data")
         if data_field is not None:
-            nested = _extract_text_value(data_field)
+            nested = _extract_text(data_field)
             if isinstance(nested, str):
                 return nested
     if isinstance(data, list):

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -154,6 +154,44 @@ def test_query_llm_handles_openai_content_list(
     assert result.text == "Hello world"
 
 
+def test_query_llm_handles_openai_content_value_objects(
+    tmp_path: Path,
+    llm_test_server: Tuple[str, type[_RecordingHandler]],
+) -> None:
+    base_url, handler = llm_test_server
+    handler.responses.append(
+        (
+            200,
+            {"Content-Type": "application/json"},
+            json.dumps(
+                {
+                    "choices": [
+                        {
+                            "message": {
+                                "content": [
+                                    {
+                                        "type": "output_text",
+                                        "text": {"value": "Hello"},
+                                    },
+                                    {
+                                        "type": "output_text",
+                                        "text": {"value": " world"},
+                                    },
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ).encode("utf-8"),
+        )
+    )
+    llms_file = _write_llms_file(tmp_path, base_url)
+
+    result = query_llm("Responses API", path=llms_file)
+
+    assert result.text == "Hello world"
+
+
 def test_query_llm_handles_openai_delta_segments(
     tmp_path: Path,
     llm_test_server: Tuple[str, type[_RecordingHandler]],


### PR DESCRIPTION
## Summary
- flatten OpenAI Responses API segments whose text payload is stored under `text.value`
- document the behaviour in the README and llms guide
- add a regression test covering the new response shape

## Testing
- pre-commit run --all-files
- make test

------
https://chatgpt.com/codex/tasks/task_e_68e4c12c2e0c832fa8f915da9c2df873