### PR TITLE
Add staged diff secret scanner and supporting tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,4 +2,10 @@
 
 1. Fork and clone the repository.
 2. Run `pre-commit run --all-files` and `make test` before committing.
-3. Open a pull request describing your changes.
+3. Scan your staged changes for secrets before committing:
+
+   ```bash
+   git diff --cached | ./scripts/scan-secrets.py
+   ```
+
+4. Open a pull request describing your changes.

--- a/README.md
+++ b/README.md
@@ -131,6 +131,18 @@ pre-commit run --all-files
 make test
 ```
 
+### Secret scanning
+
+Scan staged changes for accidentally committed credentials before creating a
+commit:
+
+```bash
+git diff --cached | ./scripts/scan-secrets.py
+```
+
+Lines that intentionally contain tokens can opt out with
+`# pragma: allowlist secret`.
+
 Playwright powers the end-to-end coverage for the enclosure viewer. Install its
 runtime once before running the tests locally:
 

--- a/scripts/scan-secrets.py
+++ b/scripts/scan-secrets.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Lightweight diff scanner that flags obvious secrets before commit."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import sys
+from dataclasses import dataclass
+from typing import Iterable, List
+
+ALLOWLIST_TOKEN = "pragma: allowlist secret"
+
+_PATTERNS: dict[str, re.Pattern[str]] = {
+    "AWS access key": re.compile(r"AKIA[0-9A-Z]{16}"),
+    "AWS session key": re.compile(r"ASIA[0-9A-Z]{16}"),
+    "GitHub token": re.compile(r"ghp_[A-Za-z0-9]{36}"),
+    "GitLab token": re.compile(r"glpat-[A-Za-z0-9-_]{20,}"),
+    "Slack token": re.compile(r"xox[baprs]-[A-Za-z0-9-]{10,}"),
+    "Stripe secret key": re.compile(r"sk_(live|test)_[A-Za-z0-9]{24,}"),
+    "Google API key": re.compile(r"AIza[0-9A-Za-z-_]{35}"),
+    "OpenAI key": re.compile(r"sk-[A-Za-z0-9]{20,}"),
+    "Private key block": re.compile(r"-----BEGIN [A-Z ]+-----"),
+    "Generic secret assignment": re.compile(
+        (
+            r"(?i)(?:api[_-]?key|secret|token|password)\s*[:=]\s*"
+            r"[\"']?[A-Za-z0-9\-_/+=]{12,}"
+        )
+    ),
+}
+
+_HIGH_ENTROPY_CANDIDATE = re.compile(r"[A-Za-z0-9+/=_-]{20,}")
+
+
+@dataclass
+class Finding:
+    line_no: int
+    rule: str
+    value: str
+    line: str
+
+
+def _shannon_entropy(value: str) -> float:
+    counts: dict[str, int] = {}
+    for char in value:
+        counts[char] = counts.get(char, 0) + 1
+    length = len(value)
+    if length == 0:
+        return 0.0
+    entropy = 0.0
+    for count in counts.values():
+        probability = count / length
+        entropy -= probability * math.log2(probability)
+    return entropy
+
+
+def _detect_high_entropy_values(
+    text: str, *, threshold: float, min_length: int
+) -> Iterable[str]:
+    for match in _HIGH_ENTROPY_CANDIDATE.finditer(text):
+        value = match.group(0)
+        if len(value) < min_length:
+            continue
+        if _shannon_entropy(value) >= threshold:
+            yield value
+
+
+def scan_diff(
+    diff_text: str,
+    *,
+    entropy_threshold: float = 4.0,
+    min_length: int = 32,
+) -> List[Finding]:
+    findings: List[Finding] = []
+    for idx, raw_line in enumerate(diff_text.splitlines(), start=1):
+        if not raw_line.startswith("+") or raw_line.startswith("+++"):
+            continue
+        line = raw_line[1:]
+        if ALLOWLIST_TOKEN in line:
+            continue
+        for rule, pattern in _PATTERNS.items():
+            match = pattern.search(line)
+            if match:
+                findings.append(
+                    Finding(
+                        line_no=idx,
+                        rule=rule,
+                        value=match.group(0),
+                        line=line.strip(),
+                    )
+                )
+                break
+        else:
+            for value in _detect_high_entropy_values(
+                line,
+                threshold=entropy_threshold,
+                min_length=min_length,
+            ):
+                findings.append(
+                    Finding(
+                        line_no=idx,
+                        rule="High entropy string",
+                        value=value,
+                        line=line.strip(),
+                    )
+                )
+                break
+    return findings
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Scan a unified diff from stdin for potential secrets.",
+    )
+    parser.add_argument(
+        "--entropy-threshold",
+        type=float,
+        default=4.0,
+        help=(
+            "Minimum Shannon entropy (bits) to flag high-entropy strings "
+            "(default: 4.0)"
+        ),
+    )
+    parser.add_argument(
+        "--min-length",
+        type=int,
+        default=32,
+        help=("Minimum length for entropy-based detection " "(default: 32)"),
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit findings as JSON for tooling integration.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    diff_text = sys.stdin.read()
+    if not diff_text.strip():
+        return 0
+
+    findings = scan_diff(
+        diff_text,
+        entropy_threshold=args.entropy_threshold,
+        min_length=args.min_length,
+    )
+
+    if not findings:
+        return 0
+
+    if args.json:
+        payload = [finding.__dict__ for finding in findings]
+        json.dump(payload, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    else:
+        print("Potential secrets detected:\n")
+        for finding in findings:
+            print(f"- line {finding.line_no}: {finding.rule}")
+            print(f"  snippet: {finding.line}")
+        print(
+            "\nIf this is a false positive, add 'pragma: allowlist secret' "
+            "to the line or adjust the commit.",
+        )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_scan_secrets.py
+++ b/tests/test_scan_secrets.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "scan-secrets.py"
+TOKENS = {
+    "stripe": (
+        "sk_test_",
+        "abcdefghijklmnopqrstuvwxyz123",
+    ),  # pragma: allowlist secret
+    "aws": (
+        "AKIA",
+        "0123456789ABCDEF",
+    ),  # pragma: allowlist secret
+    "github": (
+        "ghp_",
+        "abcdefghijklmnopqrstuvwxyz0123456789",  # pragma: allowlist secret
+    ),
+    "slack": (
+        "xoxb-",
+        "1234567890-ABCDEFGHIJ",
+    ),  # pragma: allowlist secret
+}
+STRIPE_TEST_KEY = "".join(TOKENS["stripe"])
+AWS_ACCESS_KEY = "".join(TOKENS["aws"])
+GITHUB_TOKEN = "".join(TOKENS["github"])
+SLACK_TOKEN = "".join(TOKENS["slack"])
+PASSWORD_DIFF_LINE = "".join(
+    ['+password = "SuperSecretValue123"']  # pragma: allowlist secret
+)
+
+
+def run_scan(diff: str, *extra_args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), *extra_args],
+        input=diff,
+        text=True,
+        capture_output=True,
+    )
+
+
+def build_diff(lines: list[str]) -> str:
+    return "\n".join(lines) + "\n"
+
+
+def test_scan_secrets_allows_clean_diff():
+    diff = build_diff(
+        [
+            "diff --git a/file b/file",
+            "+++ b/file",
+            "@@",
+            "+print('hello world')",
+        ]
+    )
+    result = run_scan(diff)
+    assert result.returncode == 0
+    assert not result.stdout
+    assert not result.stderr
+
+
+def test_scan_secrets_detects_pattern():
+    diff = build_diff(
+        [
+            "diff --git a/file b/file",
+            "+++ b/file",
+            "@@",
+            f'+api_key = "{STRIPE_TEST_KEY}"',
+        ]
+    )
+    result = run_scan(diff)
+    assert result.returncode == 1
+    assert "Stripe secret key" in result.stdout
+
+
+@pytest.mark.parametrize(
+    "token",
+    [AWS_ACCESS_KEY, GITHUB_TOKEN, SLACK_TOKEN],
+)
+def test_scan_secrets_flags_known_tokens(token: str):
+    diff = build_diff(
+        [
+            "diff --git a/file b/file",
+            "+++ b/file",
+            "@@",
+            f"+value = '{token}'",
+        ]
+    )
+    result = run_scan(diff)
+    assert result.returncode == 1
+    assert token in result.stdout
+
+
+def test_scan_secrets_supports_allowlist_comment():
+    diff = build_diff(
+        [
+            "diff --git a/file b/file",
+            "+++ b/file",
+            "@@",
+            " ".join(
+                [
+                    f"+token = '{SLACK_TOKEN}'",
+                    "# pragma: allowlist secret",
+                ]
+            ),
+        ]
+    )
+    result = run_scan(diff)
+    assert result.returncode == 0
+
+
+def test_scan_secrets_outputs_json_payload():
+    diff = build_diff(
+        [
+            "diff --git a/file b/file",
+            "+++ b/file",
+            "@@",
+            PASSWORD_DIFF_LINE,
+        ]
+    )
+    result = run_scan(diff, "--json")
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert payload[0]["rule"] == "Generic secret assignment"
+    assert payload[0]["value"]


### PR DESCRIPTION
## Summary
- add a scripts/scan-secrets.py helper that scans staged diffs for credential patterns and high-entropy strings
- exercise the scanner with pytest coverage, including allowlist handling and JSON output support
- document the required secret scan step in CONTRIBUTING.md and README.md

## Testing
- python -m pre_commit run --all-files
- make test

------
https://chatgpt.com/codex/tasks/task_e_68e55c566fd4832f9966e4a3ecccb170