### PR TITLE
✨ : – handle output-style LLM responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,12 +184,14 @@ Use `sigma.query_llm` to send a prompt to the currently configured LLM endpoint.
 The helper resolves the endpoint via `llms.resolve_llm_endpoint`, sends a JSON
  payload containing the prompt, and extracts a sensible reply from common JSON
  shapes (`{"response": ...}`, `{"text": ...}`, OpenAI-style chat payloads
- `{"choices": [{"message": {"content": ...}}]}`, or streaming-style
- deltas `{"choices": [{"delta": {"content": ...}}]}`). When `message.content`
- or `delta.content` contains a list of text segments (as returned by newer
- OpenAI APIs) the helper concatenates the pieces automatically, including
- segments whose `text` field is an object with a `value` string. Plain-text
- responses are returned as-is.
+ `{"choices": [{"message": {"content": ...}}]}`, streaming-style
+ deltas `{"choices": [{"delta": {"content": ...}}]}`, and Anthropic-style
+ collections such as `{"output": ...}` or `{"outputs": ...}`). Nested response
+ objects (for example `{"response": {"choices": ...}}`) are unwrapped
+ automatically. When `message.content` or `delta.content` contains a list of text
+ segments (as returned by newer OpenAI APIs) the helper concatenates the pieces
+ automatically, including segments whose `text` field is an object with a
+ `value` string. Plain-text responses are returned as-is.
 
 ```python
 from sigma import query_llm

--- a/docs/llms-guide.md
+++ b/docs/llms-guide.md
@@ -82,10 +82,12 @@ payload to the selected HTTP(S) endpoint. It accepts an optional
 present, ensuring helper callers retain control of the final prompt value. Pass
 `prompt=None` to supply the field yourself when needed. The helper extracts a reply
 from common response shapes (`response`, `text`, the first
-`choices[].message.content`, or streaming deltas in `choices[].delta.content`).
-If the message or delta content is provided as a list of text fragments (as in
-the latest OpenAI APIs) the helper concatenates the segments for you, including
-cases where each fragment stores its text inside an object with a `value`
+`choices[].message.content`, streaming deltas in `choices[].delta.content`, and
+Anthropic-style collections such as `output` or `outputs`). Nested `response`
+objects are handled recursively so wrappers like `{"response": {"choices": ...}}`
+resolve correctly. If the message or delta content is provided as a list of text
+fragments (as in the latest OpenAI APIs) the helper concatenates the segments for you,
+including cases where each fragment stores its text inside an object with a `value`
 string. Plain-text responses are returned unchanged, and a `RuntimeError` is
 raised if a JSON response cannot be interpreted.
 

--- a/sigma/llm_client.py
+++ b/sigma/llm_client.py
@@ -55,7 +55,19 @@ def _extract_text_value(value: Any) -> str | None:
     if isinstance(value, str):
         return value
     if isinstance(value, Mapping):
-        for key in ("response", "text", "value", "content"):
+        primary_keys = (
+            "response",
+            "text",
+            "value",
+            "content",
+            "output",
+            "outputs",
+            "result",
+            "results",
+            "completion",
+            "completions",
+        )
+        for key in primary_keys:
             if key in value:
                 candidate = _extract_text_value(value[key])
                 if isinstance(candidate, str):
@@ -155,6 +167,7 @@ def _extract_text(data: Any) -> str | None:
     direct = _extract_text_value(data)
     if isinstance(direct, str):
         return direct
+
     if isinstance(data, Mapping):
         choices = data.get("choices")
         if isinstance(choices, list):
@@ -162,11 +175,23 @@ def _extract_text(data: Any) -> str | None:
                 choice_text = _extract_text_value(choice)
                 if isinstance(choice_text, str):
                     return choice_text
-        data_field = data.get("data")
-        if data_field is not None:
-            nested = _extract_text(data_field)
-            if isinstance(nested, str):
-                return nested
+
+        for key in (
+            "data",
+            "response",
+            "output",
+            "outputs",
+            "result",
+            "results",
+            "completion",
+            "completions",
+        ):
+            if key in data:
+                nested_value = data[key]
+                extracted = _extract_text(nested_value)
+                if isinstance(extracted, str):
+                    return extracted
+
     if isinstance(data, list):
         return _extract_text_value(data)
     return None

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -224,6 +224,114 @@ def test_query_llm_handles_openai_delta_segments(
     assert result.text == "Hello world"
 
 
+def test_query_llm_handles_nested_response_payload(
+    tmp_path: Path,
+    llm_test_server: Tuple[str, type[_RecordingHandler]],
+) -> None:
+    base_url, handler = llm_test_server
+    handler.responses.append(
+        (
+            200,
+            {"Content-Type": "application/json"},
+            json.dumps(
+                {
+                    "response": {
+                        "choices": [
+                            {
+                                "message": {
+                                    "content": [
+                                        {
+                                            "type": "text",
+                                            "text": {"value": "Nested"},
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ).encode("utf-8"),
+        )
+    )
+    llms_file = _write_llms_file(tmp_path, base_url)
+
+    result = query_llm("Nested response", path=llms_file)
+
+    assert result.text == "Nested"
+
+
+def test_query_llm_handles_output_collection(
+    tmp_path: Path,
+    llm_test_server: Tuple[str, type[_RecordingHandler]],
+) -> None:
+    base_url, handler = llm_test_server
+    handler.responses.append(
+        (
+            200,
+            {"Content-Type": "application/json"},
+            json.dumps(
+                {
+                    "output": [
+                        {
+                            "content": [
+                                {
+                                    "type": "text",
+                                    "text": {"value": "Hello"},
+                                },
+                                {
+                                    "type": "text",
+                                    "text": {"value": " world"},
+                                },
+                            ]
+                        }
+                    ]
+                }
+            ).encode("utf-8"),
+        )
+    )
+    llms_file = _write_llms_file(tmp_path, base_url)
+
+    result = query_llm("Output", path=llms_file)
+
+    assert result.text == "Hello world"
+
+
+def test_query_llm_handles_outputs_array(
+    tmp_path: Path,
+    llm_test_server: Tuple[str, type[_RecordingHandler]],
+) -> None:
+    base_url, handler = llm_test_server
+    handler.responses.append(
+        (
+            200,
+            {"Content-Type": "application/json"},
+            json.dumps(
+                {
+                    "outputs": [
+                        {
+                            "content": [
+                                {
+                                    "type": "text",
+                                    "text": "Segment A",
+                                },
+                                {
+                                    "type": "text",
+                                    "text": " & Segment B",
+                                },
+                            ]
+                        }
+                    ]
+                }
+            ).encode("utf-8"),
+        )
+    )
+    llms_file = _write_llms_file(tmp_path, base_url)
+
+    result = query_llm("Outputs", path=llms_file)
+
+    assert result.text == "Segment A & Segment B"
+
+
 def test_query_llm_handles_plain_text(
     tmp_path: Path,
     llm_test_server: Tuple[str, type[_RecordingHandler]],


### PR DESCRIPTION
what: extend sigma.query_llm to parse nested response/output payloads and document coverage
why: README/docs promised support for common provider shapes such as output collections
how to test: pre-commit run --all-files && make test

------
https://chatgpt.com/codex/tasks/task_e_68e55c566fd4832f9966e4a3ecccb170