### PR TITLE
Add support for OpenAI Responses API output parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,12 +184,13 @@ Use `sigma.query_llm` to send a prompt to the currently configured LLM endpoint.
 The helper resolves the endpoint via `llms.resolve_llm_endpoint`, sends a JSON
  payload containing the prompt, and extracts a sensible reply from common JSON
  shapes (`{"response": ...}`, `{"text": ...}`, OpenAI-style chat payloads
- `{"choices": [{"message": {"content": ...}}]}`, or streaming-style
- deltas `{"choices": [{"delta": {"content": ...}}]}`). When `message.content`
- or `delta.content` contains a list of text segments (as returned by newer
- OpenAI APIs) the helper concatenates the pieces automatically, including
- segments whose `text` field is an object with a `value` string. Plain-text
- responses are returned as-is.
+ `{"choices": [{"message": {"content": ...}}]}`, streaming-style
+ deltas `{"choices": [{"delta": {"content": ...}}]}`, or OpenAI Responses
+ API payloads `{"output": [{"content": ...}]}`). When `message.content`,
+ `delta.content`, or `output[].content` contains a list of text segments (as
+ returned by newer OpenAI APIs) the helper concatenates the pieces
+ automatically, including segments whose `text` field is an object with a
+ `value` string. Plain-text responses are returned as-is.
 
 ```python
 from sigma import query_llm

--- a/docs/llms-guide.md
+++ b/docs/llms-guide.md
@@ -82,12 +82,13 @@ payload to the selected HTTP(S) endpoint. It accepts an optional
 present, ensuring helper callers retain control of the final prompt value. Pass
 `prompt=None` to supply the field yourself when needed. The helper extracts a reply
 from common response shapes (`response`, `text`, the first
-`choices[].message.content`, or streaming deltas in `choices[].delta.content`).
-If the message or delta content is provided as a list of text fragments (as in
-the latest OpenAI APIs) the helper concatenates the segments for you, including
-cases where each fragment stores its text inside an object with a `value`
-string. Plain-text responses are returned unchanged, and a `RuntimeError` is
-raised if a JSON response cannot be interpreted.
+`choices[].message.content`, streaming deltas in `choices[].delta.content`, or
+OpenAI Responses API payloads in `output[].content`). If the message, delta, or
+output content is provided as a list of text fragments (as in the latest OpenAI
+APIs) the helper concatenates the segments for you, including cases where each
+fragment stores its text inside an object with a `value` string. Plain-text
+responses are returned unchanged, and a `RuntimeError` is raised if a JSON
+response cannot be interpreted.
 
 Most hosted providers also expect an `Authorization` header. Configure
 `SIGMA_LLM_AUTH_TOKEN` with your API key to add one automatically. The helper

--- a/sigma/llm_client.py
+++ b/sigma/llm_client.py
@@ -162,6 +162,11 @@ def _extract_text(data: Any) -> str | None:
                 choice_text = _extract_text_value(choice)
                 if isinstance(choice_text, str):
                     return choice_text
+        output = data.get("output")
+        if isinstance(output, list):
+            output_text = _extract_text_value(output)
+            if isinstance(output_text, str):
+                return output_text
         data_field = data.get("data")
         if data_field is not None:
             nested = _extract_text(data_field)

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -192,6 +192,42 @@ def test_query_llm_handles_openai_content_value_objects(
     assert result.text == "Hello world"
 
 
+def test_query_llm_handles_responses_api_output(
+    tmp_path: Path,
+    llm_test_server: Tuple[str, type[_RecordingHandler]],
+) -> None:
+    base_url, handler = llm_test_server
+    handler.responses.append(
+        (
+            200,
+            {"Content-Type": "application/json"},
+            json.dumps(
+                {
+                    "output": [
+                        {
+                            "content": [
+                                {
+                                    "type": "output_text",
+                                    "text": {"value": "Hello"},
+                                },
+                                {
+                                    "type": "output_text",
+                                    "text": {"value": " world"},
+                                },
+                            ]
+                        }
+                    ]
+                }
+            ).encode("utf-8"),
+        )
+    )
+    llms_file = _write_llms_file(tmp_path, base_url)
+
+    result = query_llm("Responses API output", path=llms_file)
+
+    assert result.text == "Hello world"
+
+
 def test_query_llm_handles_openai_delta_segments(
     tmp_path: Path,
     llm_test_server: Tuple[str, type[_RecordingHandler]],


### PR DESCRIPTION
## Summary
- teach `sigma.query_llm` to extract text from OpenAI Responses API payloads that use `output[].content`
- document the additional response shape and cover it with a regression test

## Testing
- pre-commit run --all-files
- make test

------
https://chatgpt.com/codex/tasks/task_e_68e55c566fd4832f9966e4a3ecccb170